### PR TITLE
Load clusters from ClickHouse staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The motivation was a pure in-memory predecessor (KD-tree + grid clustering + zst
 - Bounds-only skeleton KD-tree in Go for fast spatial pruning at high zoom levels
 - ClickHouse materialized-view rollups for low-zoom aggregation
 - Dynamic routing between rollup and skeleton paths based on zoom level (`ZSplit`, default 11)
-- Support for 30M+ points while maintaining interactive query performance
+- Verified at 300 M points with sub-20 ms low/mid-zoom queries and 137 ms at z14 city viewport on a single box
 
 ### Metrics & Metadata
 - Support for arbitrary numeric metrics on points
@@ -124,25 +124,51 @@ CLICKHOUSE_DSN=clickhouse://default:@localhost:9000/clustopher_test go test ./..
 
 ### Performance Characteristics
 
-Measured on AMD Ryzen 9 5900X (24 threads), single-node ClickHouse 24.8 in Docker, 15,000,000 random points across the CONUS bounding box. Viewports are zoom-appropriate (continental at low zoom, neighborhood at high zoom):
+Measured on AMD Ryzen 9 5900X (24 threads), single-node ClickHouse 24.8 in Docker, random points uniformly distributed across the CONUS bounding box. Viewports are zoom-appropriate (continental at low zoom, state at mid zoom, city at high zoom):
 
-| Zoom | Viewport          | `GetClusters` | Heap alloc / op |
-|------|-------------------|---------------|-----------------|
-| 2    | CONUS (60° × 24°) | **3.3 ms**    | 0.13 MB         |
-| 8    | State (5° × 5°)   | **7.4 ms**    | 3.4 MB          |
-| 14   | City (0.05° × 0.05°) | **59.7 ms** | 0.09 MB         |
+#### Scale (load + storage)
 
-Comparison to the pre-ClickHouse baseline (in-memory KD-tree + grid clustering, full CONUS bbox at every zoom — see `benchmark_results/baseline_15M.txt`):
+| Points | CH stage gen | Load (skeleton + canonical points) | Rollup OPTIMIZE FINAL | Resident heap after load | Skeleton leaves |
+|--------|-------------:|-----------------------------------:|----------------------:|-------------------------:|----------------:|
+|   5 M  |   0.7 s |    9.2 s |   17.1 s |   18 MB |  78 K |
+|  15 M  |   1.8 s |   28.6 s |   43.8 s |   33 MB | 234 K |
+|  50 M  |   6.3 s |  103.1 s |  117.6 s |   83 MB | 781 K |
+| 100 M  |  12.2 s |  216.4 s |  212.5 s |  176 MB | 1.5 M |
+| 200 M  |  26.2 s |  536.2 s |  444.2 s |  334 MB | 3.1 M |
+| 300 M  |  45.3 s |  833.7 s |  569.0 s |  444 MB | 4.7 M |
 
-| Zoom | Old (full bbox) | New (zoom-appropriate viewport) | Speedup |
-|------|-----------------|---------------------------------|---------|
-| 2    | 30.35 s         | 3.3 ms                          | ~9 200× |
-| 8    | 18.19 s         | 7.4 ms                          | ~2 460× |
-| 14   | 67.42 s         | 59.7 ms                         | ~1 130× |
+Resident heap is what the skeleton tree pins after `LoadFromCHStaging` + GC. Raw points live in ClickHouse; Go holds only the bounds-only leaf index. Rollup `OPTIMIZE FINAL` collapses per-insert parts into a single sorted run per zoom partition — needed once after bulk load so the rollup path scans contiguous data.
 
-Note: the two columns are not strictly apples-to-apples — the old benchmarks always queried the full CONUS bbox, which is unrealistic at z14 where a real viewport is one neighborhood. With zoom-appropriate viewports the new system stays interactive across the entire zoom range.
+#### Query latency (`GetClustersCH`, 5-iter warm avg)
 
-Raw results: `benchmark_results/ch_15M.txt`.
+| Points | z2 / CONUS 60°×24° | z8 / state 5°×5° | z14 / city 0.5°×0.5° | z14 clusters returned | z14 alloc/op |
+|--------|-------------------:|-----------------:|---------------------:|----------------------:|-------------:|
+|   5 M  |  **2.9 ms** | **10.5 ms** |   **3.3 ms** |   1 600 |  0.48 MB |
+|  15 M  |  **5.5 ms** | **12.9 ms** |   **6.6 ms** |   3 772 |  1.33 MB |
+|  50 M  |  **3.7 ms** | **10.4 ms** |  **13.3 ms** |  11 395 |  4.20 MB |
+| 100 M  |  **3.6 ms** | **10.2 ms** |  **29.0 ms** |  20 795 |  8.80 MB |
+| 200 M  |  **3.5 ms** | **14.9 ms** |  **69.1 ms** |  34 408 | 15.07 MB |
+| 300 M  |  **3.7 ms** | **16.5 ms** | **136.8 ms** |  44 683 | 20.46 MB |
+
+z2 and z8 (`zoom < ZSplit`, default 11) hit the per-zoom rollup materialized views in ClickHouse: latency is flat across the entire size range because a rollup-row count is bounded by the zoom-tile grid, not the underlying point count.
+
+z14 (`zoom >= ZSplit`) walks the in-memory skeleton tree, fetches the matching leaf-id ranges from ClickHouse, and runs the Supercluster-style radius clustering on the returned points. Latency scales with the *density of points inside the viewport* — at 300 M CONUS points the 0.5° × 0.5° viewport contains ≈ 50 K points, and the system returns 44 683 clusters in 137 ms (95 % of which is `fetchLeafPoints` + `clusterPoints`).
+
+#### Limits encountered
+
+300 M is the realistic ceiling on this hardware (94 GB RAM) with the current Load path. During `LoadFromCHStaging` Go materializes one `[]chSpatialRow` (12 B/row) and one `[]KDPoint` (16 B/row), and the `INSERT … SELECT … JOIN staging ⨝ id_map` runs server-side. Even with the in-place skeleton sort (introduced for this scale push) and `join_algorithm='full_sorting_merge'` (which bounds CH-server JOIN RAM), 500 M points combined Go heap (~14 GB) + ClickHouse working set + OS page cache for the ~50 GB staging partition exhaust RAM. Pushing past 300 M needs a streaming Load path: project rows on read, drop the spatial slice, keep external IDs as a packed `[]uint32`. That's the next optimization target.
+
+#### Comparison to the pre-ClickHouse baseline (15 M points)
+
+| Zoom | Old (full bbox, in-memory KD-tree) | New (zoom-appropriate viewport, CH-backed) | Speedup |
+|------|-----------------------------------:|-------------------------------------------:|--------:|
+| 2    | 30.35 s | 5.5 ms |  ~5 500× |
+| 8    | 18.19 s | 12.9 ms |  ~1 400× |
+| 14   | 67.42 s | 6.6 ms | ~10 200× |
+
+Columns are not strictly apples-to-apples — the old benchmarks always queried the full CONUS bbox, unrealistic at z14 where a real viewport is one neighborhood. With zoom-appropriate viewports the new system stays interactive across the entire zoom range, and now scales to 20× the point count of the old in-memory system (300 M vs ~15 M before the heap blew up).
+
+Raw results: `benchmark_results/scale_full_rerun.txt`, `benchmark_results/baseline_15M.txt`.
 
 ### Limitations
 - Single-node ClickHouse only; no distributed CH support

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 [![Go Tests](https://github.com/thomas-cabral/clustopher/actions/workflows/go-test.yml/badge.svg)](https://github.com/thomas-cabral/clustopher/actions/workflows/go-test.yml)
 
-Clustopher is a high-performance spatial clustering system designed to handle large-scale point datasets (30M+ points) with associated metrics and metadata. It implements a KD-tree based clustering approach similar to Mapbox's Supercluster, with ClickHouse as the canonical data store for points and per-zoom aggregations.
+Clustopher is a spatial point-clustering engine for datasets in the tens of millions of points, built to stay interactive (sub-100ms `GetClusters`) at every zoom level on a single box.
+
+It splits the problem in two. ClickHouse is the canonical store: raw points live in a `MergeTree` partitioned by cluster, and a stack of materialized views maintains a per-zoom rollup table for zooms 2–16. In Go, a bounds-only "skeleton" KD-tree (`{Bounds, IDMin, IDMax, Count}` per leaf — 28 bytes) sits in memory as a spatial index over those points, ~6.5 MB resident for 15M points. At query time the zoom level decides the path: low/mid zoom runs a single SQL aggregation against the rollup table; high zoom walks the skeleton, classifies leaves as fully-inside vs straddling the cluster radius, batches `id BETWEEN` fetches into ClickHouse for the partial leaves, and runs the Supercluster-style radius clustering only on that small leftover set.
+
+The motivation was a pure in-memory predecessor (KD-tree + grid clustering + zstd snapshots) that held every point and its metadata in Go heap. At 15M points it pinned ~9 GB of heap, took 30+ seconds to answer a low-zoom continental query, and couldn't be reloaded without deserializing a multi-GB snapshot. Pushing the points into ClickHouse and keeping only leaf bounds in Go collapses both the memory footprint and the cold-load story while letting low-zoom queries become a single rollup-table scan instead of a tree traversal.
 
 ## Key Features
 

--- a/cluster/benchmark_ch_test.go
+++ b/cluster/benchmark_ch_test.go
@@ -344,14 +344,19 @@ func benchmarkClusteringCHFirstStaged(b *testing.B, clusterID string, n int, bou
 
 func generateDenseStagingPoints(ctx context.Context, c *CHClient, clusterID string, n int, bounds KDBounds) error {
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(insertSettings))
+	// NB: previously used `randCanonical()` for x and y in the same SELECT; the
+	// CH planner folded the two calls into a single value, so every generated
+	// point landed on the diagonal `y = MinY + (x-MinX) * (MaxY-MinY)/(MaxX-MinX)`.
+	// Use cityHash64(number, salt) with distinct salts per axis so x, y, and the
+	// metric draw are independent uniform variates.
 	return c.Conn().Exec(ctx, `
         INSERT INTO clustopher.staging_points (cluster_id, external_id, x, y, metrics, metadata)
         SELECT
             ? AS cluster_id,
             toUInt32(number + 1) AS external_id,
-            toFloat32(? + randCanonical() * (? - ?)) AS x,
-            toFloat32(? + randCanonical() * (? - ?)) AS y,
-            map('value', toFloat32(randCanonical() * 100)) AS metrics,
+            toFloat32(? + (cityHash64(number, 1) / 18446744073709551615.0) * (? - ?)) AS x,
+            toFloat32(? + (cityHash64(number, 2) / 18446744073709551615.0) * (? - ?)) AS y,
+            map('value', toFloat32((cityHash64(number, 3) / 18446744073709551615.0) * 100)) AS metrics,
             map('type', 'test') AS metadata
         FROM numbers(?)
     `, clusterID, bounds.MinX, bounds.MaxX, bounds.MinX, bounds.MinY, bounds.MaxY, bounds.MinY, uint64(n))

--- a/cluster/benchmark_ch_test.go
+++ b/cluster/benchmark_ch_test.go
@@ -7,6 +7,9 @@ import (
 	"runtime"
 	"strconv"
 	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 // viewportForZoom returns a realistic viewport for the given zoom level.
@@ -87,3 +90,269 @@ func benchmarkClusteringCHHuge(b *testing.B, numPoints int, zoom int) {
 func BenchmarkClusteringCHHuge_LowZoom(b *testing.B)  { benchmarkClusteringCHHuge(b, 15_000_000, 2) }
 func BenchmarkClusteringCHHuge_MidZoom(b *testing.B)  { benchmarkClusteringCHHuge(b, 15_000_000, 8) }
 func BenchmarkClusteringCHHuge_HighZoom(b *testing.B) { benchmarkClusteringCHHuge(b, 15_000_000, 14) }
+
+func TestPerfClusteringCHDenseNYC_15M(t *testing.T) {
+	if os.Getenv("CLUSTOPHER_PERF_TESTS") != "1" {
+		t.Skip("set CLUSTOPHER_PERF_TESTS=1 to run the 15M dense NYC perf test")
+	}
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	const n = 15_000_000
+	clusterID := "PERF_DENSE_NYC_15M"
+	nycBounds := KDBounds{MinX: -74.2591, MinY: 40.4774, MaxX: -73.7004, MaxY: 40.9176}
+
+	_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+	for z := 2; z <= 16; z++ {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+	}
+	defer func() {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+		for z := 2; z <= 16; z++ {
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+		}
+	}()
+
+	sc := NewSupercluster(SuperclusterOptions{
+		MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40,
+		Extent: 512, NodeSize: 64,
+	})
+	sc.SetCHClient(c)
+	sc.SetClusterID(clusterID)
+
+	start := time.Now()
+	pts := generateRandomPoints(n, nycBounds.MinX, nycBounds.MaxX, nycBounds.MinY, nycBounds.MaxY)
+	t.Logf("generated %d NYC points in %s", n, time.Since(start))
+
+	start = time.Now()
+	if err := sc.Load(pts); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	t.Logf("loaded %d NYC points into ClickHouse in %s", n, time.Since(start))
+	pts = nil
+	runtime.GC()
+
+	start = time.Now()
+	for z := 2; z <= 16; z++ {
+		_ = c.Conn().Exec(ctx, "OPTIMIZE TABLE clustopher.rollup_z"+strconv.Itoa(z)+" PARTITION ? FINAL", clusterID)
+	}
+	t.Logf("optimized rollup partitions in %s", time.Since(start))
+
+	for _, zoom := range []int{8, 10, 11, 12, 14} {
+		start = time.Now()
+		clusters, err := sc.GetClustersCH(ctx, nycBounds, zoom)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("GetClustersCH zoom=%d: %v", zoom, err)
+		}
+		var total uint64
+		for _, c := range clusters {
+			total += uint64(c.Count)
+		}
+		t.Logf("zoom=%d viewport=NYC clusters=%d total_count=%d elapsed=%s", zoom, len(clusters), total, elapsed)
+	}
+}
+
+// BenchmarkClusteringCHDenseNYC_15M is intended for Go pprof runs against a
+// dense single-city dataset.
+//
+//	CLICKHOUSE_DSN=clickhouse://default:@127.0.0.1:19000/clustopher \
+//	  go test ./cluster -run '^$' -bench '^BenchmarkClusteringCHDenseNYC_15M$' \
+//	  -benchtime=1x -count=1 -timeout=30m -benchmem \
+//	  -cpuprofile=nyc_cpu.pprof -memprofile=nyc_mem.pprof
+//
+// Inspect with:
+//
+//	go tool pprof -http=:0 ./cluster.test nyc_cpu.pprof
+//	go tool pprof -http=:0 ./cluster.test nyc_mem.pprof
+func BenchmarkClusteringCHDenseNYC_15M(b *testing.B) {
+	b.ReportAllocs()
+
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		b.Skip("CLICKHOUSE_DSN not set")
+	}
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		b.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		b.Fatalf("migrations: %v", err)
+	}
+
+	const n = 15_000_000
+	clusterID := "BENCH_DENSE_NYC_15M"
+	nycBounds := KDBounds{MinX: -74.2591, MinY: 40.4774, MaxX: -73.7004, MaxY: 40.9176}
+
+	_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+	for z := 2; z <= 16; z++ {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+	}
+	defer func() {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+		for z := 2; z <= 16; z++ {
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+		}
+	}()
+
+	sc := NewSupercluster(SuperclusterOptions{
+		MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40,
+		Extent: 512, NodeSize: 64,
+	})
+	sc.SetCHClient(c)
+	sc.SetClusterID(clusterID)
+
+	pts := generateRandomPoints(n, nycBounds.MinX, nycBounds.MaxX, nycBounds.MinY, nycBounds.MaxY)
+	loadStart := time.Now()
+	if err := sc.Load(pts); err != nil {
+		b.Fatalf("Load: %v", err)
+	}
+	b.Logf("loaded %d NYC points in %s", n, time.Since(loadStart))
+	for z := 2; z <= 16; z++ {
+		_ = c.Conn().Exec(ctx, "OPTIMIZE TABLE clustopher.rollup_z"+strconv.Itoa(z)+" PARTITION ? FINAL", clusterID)
+	}
+
+	for _, zoom := range []int{8, 10, 11, 12, 14} {
+		b.Run(fmt.Sprintf("Zoom%d_FullNYCViewport", zoom), func(b *testing.B) {
+			var before, after runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+
+			var clusters []ClusterNode
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				clusters, err = sc.GetClustersCH(ctx, nycBounds, zoom)
+				if err != nil {
+					b.Fatalf("GetClustersCH: %v", err)
+				}
+			}
+			b.StopTimer()
+
+			runtime.ReadMemStats(&after)
+			b.ReportMetric(float64(after.TotalAlloc-before.TotalAlloc)/1024/1024, "MB/op")
+			b.ReportMetric(float64(len(clusters)), "clusters/op")
+		})
+	}
+}
+
+// BenchmarkClusteringCHFirstDenseNYC_15M loads generated dense NYC data into
+// ClickHouse staging first, then builds the exact KD leaf order from compact
+// spatial rows streamed out of CH. This profiles the proposed CH-first ingest
+// path without Go materializing []Point maps/interfaces for the source data.
+//
+//	CLICKHOUSE_DSN=clickhouse://default:@127.0.0.1:19000/clustopher \
+//	  go test ./cluster -run '^$' -bench '^BenchmarkClusteringCHFirstDenseNYC_15M$' \
+//	  -benchtime=1x -count=1 -timeout=30m -benchmem \
+//	  -cpuprofile=benchmark_results/nyc_chfirst_cpu.pprof \
+//	  -memprofile=benchmark_results/nyc_chfirst_mem.pprof -v
+func BenchmarkClusteringCHFirstDenseNYC_15M(b *testing.B) {
+	benchmarkClusteringCHFirstStaged(b, "BENCH_CHFIRST_DENSE_NYC_15M", 15_000_000, KDBounds{
+		MinX: -74.2591, MinY: 40.4774, MaxX: -73.7004, MaxY: 40.9176,
+	})
+}
+
+func BenchmarkClusteringCHFirstWesternHemisphere_15M(b *testing.B) {
+	benchmarkClusteringCHFirstStaged(b, "BENCH_CHFIRST_WESTERN_HEMISPHERE_15M", 15_000_000, KDBounds{
+		MinX: -180, MinY: -60, MaxX: 0, MaxY: 85,
+	})
+}
+
+func benchmarkClusteringCHFirstStaged(b *testing.B, clusterID string, n int, bounds KDBounds) {
+	b.ReportAllocs()
+
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		b.Skip("CLICKHOUSE_DSN not set")
+	}
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		b.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		b.Fatalf("migrations: %v", err)
+	}
+
+	cleanup := func() {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+		for z := 2; z <= 16; z++ {
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+		}
+	}
+	cleanup()
+	defer cleanup()
+
+	stageStart := time.Now()
+	if err := generateDenseStagingPoints(ctx, c, clusterID, n, bounds); err != nil {
+		b.Fatalf("generate staging: %v", err)
+	}
+	b.Logf("generated %d staged points in CH in %s", n, time.Since(stageStart))
+
+	sc := NewSupercluster(SuperclusterOptions{
+		MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40,
+		Extent: 512, NodeSize: 64,
+	})
+	sc.SetCHClient(c)
+	sc.SetClusterID(clusterID)
+
+	loadStart := time.Now()
+	if err := sc.LoadFromCHStaging(ctx); err != nil {
+		b.Fatalf("LoadFromCHStaging: %v", err)
+	}
+	b.Logf("loaded %d points from CH staging in %s", n, time.Since(loadStart))
+	for z := 2; z <= 16; z++ {
+		_ = c.Conn().Exec(ctx, "OPTIMIZE TABLE clustopher.rollup_z"+strconv.Itoa(z)+" PARTITION ? FINAL", clusterID)
+	}
+
+	for _, zoom := range []int{8, 10, 11, 12, 14} {
+		b.Run(fmt.Sprintf("Zoom%d_FullNYCViewport", zoom), func(b *testing.B) {
+			var before, after runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+
+			var clusters []ClusterNode
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				clusters, err = sc.GetClustersCH(ctx, bounds, zoom)
+				if err != nil {
+					b.Fatalf("GetClustersCH: %v", err)
+				}
+			}
+			b.StopTimer()
+
+			runtime.ReadMemStats(&after)
+			b.ReportMetric(float64(after.TotalAlloc-before.TotalAlloc)/1024/1024, "MB/op")
+			b.ReportMetric(float64(len(clusters)), "clusters/op")
+		})
+	}
+}
+
+func generateDenseStagingPoints(ctx context.Context, c *CHClient, clusterID string, n int, bounds KDBounds) error {
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(insertSettings))
+	return c.Conn().Exec(ctx, `
+        INSERT INTO clustopher.staging_points (cluster_id, external_id, x, y, metrics, metadata)
+        SELECT
+            ? AS cluster_id,
+            toUInt32(number + 1) AS external_id,
+            toFloat32(? + randCanonical() * (? - ?)) AS x,
+            toFloat32(? + randCanonical() * (? - ?)) AS y,
+            map('value', toFloat32(randCanonical() * 100)) AS metrics,
+            map('type', 'test') AS metadata
+        FROM numbers(?)
+    `, clusterID, bounds.MinX, bounds.MaxX, bounds.MinX, bounds.MinY, bounds.MaxY, bounds.MinY, uint64(n))
+}

--- a/cluster/benchmark_scale_test.go
+++ b/cluster/benchmark_scale_test.go
@@ -1,0 +1,294 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestScalePerf runs the CH-first staging path at escalating dataset sizes and
+// dumps a markdown table with load time, per-zoom GetClustersCH timing, and
+// resident skeleton size. Partitions are dropped between sizes so CH is reset
+// to a clean state each round.
+//
+// Gated by CLUSTOPHER_SCALE_TESTS=1.
+//
+// Sizes (in millions, comma-separated) override the default with
+// CLUSTOPHER_SCALE_SIZES, e.g. "50,100,200,500".
+//
+//	CLUSTOPHER_SCALE_TESTS=1 \
+//	CLUSTOPHER_SCALE_SIZES=50,100,200 \
+//	CLICKHOUSE_DSN=clickhouse://default:@127.0.0.1:19000/clustopher \
+//	  go test ./cluster -run TestScalePerf -v -timeout 4h
+func TestScalePerf(t *testing.T) {
+	if os.Getenv("CLUSTOPHER_SCALE_TESTS") != "1" {
+		t.Skip("set CLUSTOPHER_SCALE_TESTS=1 to run scale perf test")
+	}
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+
+	sizes := parseScaleSizes(os.Getenv("CLUSTOPHER_SCALE_SIZES"))
+	if len(sizes) == 0 {
+		sizes = []int{15_000_000, 50_000_000, 100_000_000, 200_000_000}
+	}
+
+	zooms := []int{2, 8, 14}
+	conus := KDBounds{MinX: -125, MinY: 25, MaxX: -65, MaxY: 49}
+
+	// Override the default viewportForZoom for the high-zoom case: 0.05° × 0.05°
+	// over a uniform CONUS sample is too sparse for the skeleton path to do real
+	// work at higher N. Use a 0.5° × 0.5° city-scale window in the dense centre
+	// of CONUS so the skeleton walk has actual leaves to chew on.
+	scaleViewport := func(zoom int) KDBounds {
+		if zoom >= 11 {
+			return KDBounds{MinX: -100.25, MinY: 39.25, MaxX: -99.75, MaxY: 39.75}
+		}
+		return viewportForZoom(zoom)
+	}
+	scaleViewportTag := func(zoom int) string {
+		if zoom >= 11 {
+			return "city (0.5°×0.5°)"
+		}
+		return viewportTag(zoom)
+	}
+
+	type zoomResult struct {
+		zoom        int
+		elapsedMs   float64
+		mbPerOp     float64
+		clusters    int
+		viewportTag string
+	}
+	type sizeResult struct {
+		n                  int
+		stageSec           float64
+		loadSec            float64
+		optimizeSec        float64
+		skeletonResidentMB float64
+		leafCount          int
+		zoom               []zoomResult
+		err                string
+	}
+
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	var results []sizeResult
+
+	for _, n := range sizes {
+		clusterID := fmt.Sprintf("SCALE_%d", n)
+		t.Logf("=== scale size %s ===", humanCount(n))
+
+		cleanup := func() {
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+			for z := 2; z <= 16; z++ {
+				_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+			}
+		}
+		cleanup()
+
+		res := sizeResult{n: n}
+
+		stageStart := time.Now()
+		if err := generateDenseStagingPoints(ctx, c, clusterID, n, conus); err != nil {
+			res.err = fmt.Sprintf("stage: %v", err)
+			results = append(results, res)
+			cleanup()
+			t.Logf("FAIL %s: %s", humanCount(n), res.err)
+			continue
+		}
+		res.stageSec = time.Since(stageStart).Seconds()
+		t.Logf("staged %s points in CH in %.1fs", humanCount(n), res.stageSec)
+
+		sc := NewSupercluster(SuperclusterOptions{
+			MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40,
+			Extent: 512, NodeSize: 64,
+		})
+		sc.SetCHClient(c)
+		sc.SetClusterID(clusterID)
+
+		loadStart := time.Now()
+		if err := sc.LoadFromCHStaging(ctx); err != nil {
+			res.err = fmt.Sprintf("load: %v", err)
+			results = append(results, res)
+			cleanup()
+			t.Logf("FAIL %s: %s", humanCount(n), res.err)
+			continue
+		}
+		res.loadSec = time.Since(loadStart).Seconds()
+		t.Logf("loaded %s points (CH-first) in %.1fs", humanCount(n), res.loadSec)
+
+		// Free intermediates and force GC so the resident-after-load measurement
+		// reflects what the skeleton actually pins.
+		runtime.GC()
+		debug.FreeOSMemory()
+
+		var ms runtime.MemStats
+		runtime.ReadMemStats(&ms)
+		res.skeletonResidentMB = float64(ms.HeapAlloc) / (1024 * 1024)
+		if sc.Skeleton != nil {
+			res.leafCount = len(sc.Skeleton.Leaves)
+		}
+
+		// Free staging now that the canonical points table is populated.
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+
+		optStart := time.Now()
+		for z := 2; z <= 16; z++ {
+			_ = c.Conn().Exec(ctx, "OPTIMIZE TABLE clustopher.rollup_z"+strconv.Itoa(z)+" PARTITION ? FINAL", clusterID)
+		}
+		res.optimizeSec = time.Since(optStart).Seconds()
+		t.Logf("optimized rollup partitions in %.1fs", res.optimizeSec)
+
+		for _, z := range zooms {
+			bounds := scaleViewport(z)
+			t.Logf("z=%d query bounds=%+v skeleton_leaves=%d", z, bounds, res.leafCount)
+			// Warmup query, ignored.
+			warm, err := sc.GetClustersCH(ctx, bounds, z)
+			if err != nil {
+				t.Logf("warmup zoom=%d err: %v", z, err)
+			} else {
+				t.Logf("warmup zoom=%d clusters=%d", z, len(warm))
+			}
+
+			var before, after runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+
+			const iters = 5
+			start := time.Now()
+			var clusters []ClusterNode
+			for i := 0; i < iters; i++ {
+				clusters, err = sc.GetClustersCH(ctx, bounds, z)
+				if err != nil {
+					t.Fatalf("GetClustersCH z=%d: %v", z, err)
+				}
+			}
+			elapsed := time.Since(start) / iters
+			runtime.ReadMemStats(&after)
+
+			zr := zoomResult{
+				zoom:        z,
+				elapsedMs:   float64(elapsed.Microseconds()) / 1000.0,
+				mbPerOp:     float64(after.TotalAlloc-before.TotalAlloc) / float64(iters) / (1024 * 1024),
+				clusters:    len(clusters),
+				viewportTag: scaleViewportTag(z),
+			}
+			res.zoom = append(res.zoom, zr)
+			t.Logf("zoom=%d viewport=%s clusters=%d avg=%s alloc=%.2fMB/op",
+				z, zr.viewportTag, zr.clusters, elapsed, zr.mbPerOp)
+		}
+
+		results = append(results, res)
+		cleanup()
+		runtime.GC()
+		debug.FreeOSMemory()
+	}
+
+	// Render markdown report.
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Clustopher scale results\n\n")
+	fmt.Fprintf(&b, "Bench host: %s, GOMAXPROCS=%d, CONUS bounds (-125,25,-65,49).\n\n",
+		runtime.GOOS+"/"+runtime.GOARCH, runtime.GOMAXPROCS(0))
+	fmt.Fprintf(&b, "## Load + storage\n\n")
+	fmt.Fprintf(&b, "| Points | CH stage gen | Load (skeleton build + CH point write) | Rollup OPTIMIZE | Resident heap after load | Skeleton leaves |\n")
+	fmt.Fprintf(&b, "|--------|--------------|----------------------------------------|------------------|--------------------------|------------------|\n")
+	for _, r := range results {
+		if r.err != "" {
+			fmt.Fprintf(&b, "| %s | — | — | — | — | FAIL: %s |\n", humanCount(r.n), r.err)
+			continue
+		}
+		fmt.Fprintf(&b, "| %s | %.1fs | %.1fs | %.1fs | %.1f MB | %s |\n",
+			humanCount(r.n), r.stageSec, r.loadSec, r.optimizeSec,
+			r.skeletonResidentMB, humanCount(r.leafCount))
+	}
+	fmt.Fprintf(&b, "\n## Query latency (GetClustersCH, 5-iter avg)\n\n")
+	fmt.Fprintf(&b, "| Points | Zoom | Viewport | Clusters returned | Avg latency | Alloc/op |\n")
+	fmt.Fprintf(&b, "|--------|------|----------|-------------------|-------------|----------|\n")
+	for _, r := range results {
+		for _, zr := range r.zoom {
+			fmt.Fprintf(&b, "| %s | %d | %s | %d | **%.1f ms** | %.2f MB |\n",
+				humanCount(r.n), zr.zoom, zr.viewportTag, zr.clusters, zr.elapsedMs, zr.mbPerOp)
+		}
+	}
+
+	report := b.String()
+	if err := os.MkdirAll("../benchmark_results", 0o755); err == nil {
+		out := fmt.Sprintf("../benchmark_results/scale_%s.md", time.Now().Format("20060102_150405"))
+		if werr := os.WriteFile(out, []byte(report), 0o644); werr == nil {
+			t.Logf("wrote report to %s", out)
+		}
+	}
+	t.Log("\n" + report)
+}
+
+func parseScaleSizes(s string) []int {
+	if s == "" {
+		return nil
+	}
+	out := []int{}
+	for _, tok := range strings.Split(s, ",") {
+		tok = strings.TrimSpace(strings.ToLower(tok))
+		if tok == "" {
+			continue
+		}
+		mult := 1
+		switch {
+		case strings.HasSuffix(tok, "b"):
+			mult = 1_000_000_000
+			tok = strings.TrimSuffix(tok, "b")
+		case strings.HasSuffix(tok, "m"):
+			mult = 1_000_000
+			tok = strings.TrimSuffix(tok, "m")
+		case strings.HasSuffix(tok, "k"):
+			mult = 1_000
+			tok = strings.TrimSuffix(tok, "k")
+		}
+		v, err := strconv.Atoi(tok)
+		if err != nil {
+			continue
+		}
+		out = append(out, v*mult)
+	}
+	return out
+}
+
+func humanCount(n int) string {
+	switch {
+	case n >= 1_000_000_000:
+		return fmt.Sprintf("%.1fB", float64(n)/1_000_000_000)
+	case n >= 1_000_000:
+		return fmt.Sprintf("%dM", n/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%dK", n/1_000)
+	default:
+		return strconv.Itoa(n)
+	}
+}
+
+func viewportTag(zoom int) string {
+	switch {
+	case zoom <= 4:
+		return "CONUS (60°×24°)"
+	case zoom <= 10:
+		return "state (5°×5°)"
+	default:
+		return "neighborhood (0.05°×0.05°)"
+	}
+}

--- a/cluster/ch_client.go
+++ b/cluster/ch_client.go
@@ -14,6 +14,7 @@ type CHConfig struct {
 
 type CHClient struct {
 	conn driver.Conn
+	dsn  string
 }
 
 func NewCHClient(ctx context.Context, cfg CHConfig) (*CHClient, error) {
@@ -29,9 +30,16 @@ func NewCHClient(ctx context.Context, cfg CHConfig) (*CHClient, error) {
 		conn.Close()
 		return nil, fmt.Errorf("ping clickhouse: %w", err)
 	}
-	return &CHClient{conn: conn}, nil
+	return &CHClient{conn: conn, dsn: cfg.DSN}, nil
 }
 
-func (c *CHClient) Conn() driver.Conn             { return c.conn }
+func (c *CHClient) Conn() driver.Conn              { return c.conn }
 func (c *CHClient) Ping(ctx context.Context) error { return c.conn.Ping(ctx) }
-func (c *CHClient) Close() error                 { return c.conn.Close() }
+func (c *CHClient) Close() error                   { return c.conn.Close() }
+
+func (c *CHClient) Clone(ctx context.Context) (*CHClient, error) {
+	if c.dsn == "" {
+		return nil, fmt.Errorf("clone clickhouse client: original DSN unavailable")
+	}
+	return NewCHClient(ctx, CHConfig{DSN: c.dsn})
+}

--- a/cluster/ch_ingest.go
+++ b/cluster/ch_ingest.go
@@ -28,6 +28,21 @@ type CHPointRow struct {
 	Metadata   map[string]string
 }
 
+type CHStagingPointRow struct {
+	ClusterID  string
+	ExternalID uint32
+	X          float32
+	Y          float32
+	Metrics    map[string]float32
+	Metadata   map[string]string
+}
+
+type CHPointIDMapRow struct {
+	LoadID     uint64
+	ExternalID uint32
+	InternalID uint32
+}
+
 // InsertPoints batches rows into clustopher.points using the native protocol.
 // Rows should already be in (cluster_id, id) primary-key order to minimize
 // MergeTree merges.
@@ -46,6 +61,44 @@ func (c *CHClient) InsertPoints(ctx context.Context, rows []CHPointRow) error {
 	}
 	if err := batch.Send(); err != nil {
 		return fmt.Errorf("send batch: %w", err)
+	}
+	return nil
+}
+
+func (c *CHClient) InsertStagingPoints(ctx context.Context, rows []CHStagingPointRow) error {
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(insertSettings))
+	batch, err := c.conn.PrepareBatch(ctx,
+		"INSERT INTO clustopher.staging_points (cluster_id, external_id, x, y, metrics, metadata)")
+	if err != nil {
+		return fmt.Errorf("prepare staging batch: %w", err)
+	}
+	for i := range rows {
+		r := &rows[i]
+		if err := batch.Append(r.ClusterID, r.ExternalID, r.X, r.Y, r.Metrics, r.Metadata); err != nil {
+			return fmt.Errorf("append staging row %d: %w", i, err)
+		}
+	}
+	if err := batch.Send(); err != nil {
+		return fmt.Errorf("send staging batch: %w", err)
+	}
+	return nil
+}
+
+func (c *CHClient) InsertPointIDMap(ctx context.Context, rows []CHPointIDMapRow) error {
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(insertSettings))
+	batch, err := c.conn.PrepareBatch(ctx,
+		"INSERT INTO clustopher.point_id_map_load (load_id, external_id, internal_id)")
+	if err != nil {
+		return fmt.Errorf("prepare id map batch: %w", err)
+	}
+	for i := range rows {
+		r := &rows[i]
+		if err := batch.Append(r.LoadID, r.ExternalID, r.InternalID); err != nil {
+			return fmt.Errorf("append id map row %d: %w", i, err)
+		}
+	}
+	if err := batch.Send(); err != nil {
+		return fmt.Errorf("send id map batch: %w", err)
 	}
 	return nil
 }

--- a/cluster/ch_ingest_test.go
+++ b/cluster/ch_ingest_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func TestInsertPoints_WritesAllRows(t *testing.T) {
@@ -133,6 +134,201 @@ func TestSuperclusterOpen_RebuildsSkeleton(t *testing.T) {
 	}
 
 	_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION 'TEST_OPEN'")
+}
+
+func TestSuperclusterLoadFromCHStaging_WritesCanonicalPoints(t *testing.T) {
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	clusterID := "TEST_STAGE_LOAD_" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+	_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+	for z := 2; z <= 16; z++ {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+	}
+	defer func() {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+		for z := 2; z <= 16; z++ {
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+		}
+	}()
+
+	rows := []CHStagingPointRow{
+		{ClusterID: clusterID, ExternalID: 100, X: -74.0, Y: 40.7, Metrics: map[string]float32{"v": 1}, Metadata: map[string]string{"kind": "a"}},
+		{ClusterID: clusterID, ExternalID: 101, X: -74.1, Y: 40.8, Metrics: map[string]float32{"v": 2}, Metadata: map[string]string{"kind": "b"}},
+		{ClusterID: clusterID, ExternalID: 102, X: -73.9, Y: 40.6, Metrics: map[string]float32{"v": 3}, Metadata: map[string]string{"kind": "c"}},
+	}
+	if err := c.InsertStagingPoints(ctx, rows); err != nil {
+		t.Fatalf("InsertStagingPoints: %v", err)
+	}
+
+	sc := NewSupercluster(SuperclusterOptions{
+		MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40,
+		Extent: 512, NodeSize: 2,
+	})
+	sc.SetCHClient(c)
+	sc.SetClusterID(clusterID)
+	if err := sc.LoadFromCHStaging(ctx); err != nil {
+		t.Fatalf("LoadFromCHStaging: %v", err)
+	}
+	if sc.Skeleton == nil || len(sc.Skeleton.Leaves) == 0 {
+		t.Fatal("missing skeleton")
+	}
+
+	var n uint64
+	if err := c.Conn().QueryRow(ctx,
+		"SELECT count() FROM clustopher.points WHERE cluster_id = ?", clusterID).Scan(&n); err != nil {
+		t.Fatalf("count points: %v", err)
+	}
+	if n != uint64(len(rows)) {
+		t.Fatalf("points count = %d, want %d", n, len(rows))
+	}
+
+	var maps uint64
+	if err := c.Conn().QueryRow(ctx, `
+        SELECT count()
+        FROM clustopher.points
+        WHERE cluster_id = ? AND metrics['v'] > 0 AND metadata['kind'] != ''
+    `, clusterID).Scan(&maps); err != nil {
+		t.Fatalf("count maps: %v", err)
+	}
+	if maps != uint64(len(rows)) {
+		t.Fatalf("preserved map rows = %d, want %d", maps, len(rows))
+	}
+
+	var maxID uint32
+	if err := c.Conn().QueryRow(ctx,
+		"SELECT max(id) FROM clustopher.points WHERE cluster_id = ?", clusterID).Scan(&maxID); err != nil {
+		t.Fatalf("max id: %v", err)
+	}
+	if maxID != uint32(len(rows)) {
+		t.Fatalf("max internal id = %d, want %d", maxID, len(rows))
+	}
+}
+
+func TestLoadFromCHStaging_CanonicalMatchesStagingMetrics(t *testing.T) {
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	clusterID := "TEST_STAGE_SOURCE_TRUTH_" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+	_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+	for z := 2; z <= 16; z++ {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+	}
+	defer func() {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+		for z := 2; z <= 16; z++ {
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+		}
+	}()
+
+	rows := []CHStagingPointRow{
+		{ClusterID: clusterID, ExternalID: 10, X: -74.00, Y: 40.70, Metrics: map[string]float32{"v": 1, "w": 10}, Metadata: map[string]string{"kind": "a"}},
+		{ClusterID: clusterID, ExternalID: 20, X: -74.01, Y: 40.71, Metrics: map[string]float32{"v": 2, "w": 20}, Metadata: map[string]string{"kind": "b"}},
+		{ClusterID: clusterID, ExternalID: 30, X: -74.02, Y: 40.72, Metrics: map[string]float32{"v": 3, "w": 30}, Metadata: map[string]string{"kind": "a"}},
+		{ClusterID: clusterID, ExternalID: 40, X: -74.03, Y: 40.73, Metrics: map[string]float32{"v": 4, "w": 40}, Metadata: map[string]string{"kind": "b"}},
+	}
+	if err := c.InsertStagingPoints(ctx, rows); err != nil {
+		t.Fatalf("InsertStagingPoints: %v", err)
+	}
+
+	sc := NewSupercluster(SuperclusterOptions{
+		MinZoom: 0, MaxZoom: 16, MinPoints: 2, Radius: 40,
+		Extent: 512, NodeSize: 2,
+	})
+	sc.SetCHClient(c)
+	sc.SetClusterID(clusterID)
+	if err := sc.LoadFromCHStaging(ctx); err != nil {
+		t.Fatalf("LoadFromCHStaging: %v", err)
+	}
+
+	var stagingN, pointsN uint64
+	if err := c.Conn().QueryRow(ctx,
+		"SELECT count() FROM clustopher.staging_points WHERE cluster_id = ?", clusterID).Scan(&stagingN); err != nil {
+		t.Fatalf("count staging: %v", err)
+	}
+	if err := c.Conn().QueryRow(ctx,
+		"SELECT count() FROM clustopher.points WHERE cluster_id = ?", clusterID).Scan(&pointsN); err != nil {
+		t.Fatalf("count points: %v", err)
+	}
+	if pointsN != stagingN {
+		t.Fatalf("canonical count = %d, staging count = %d", pointsN, stagingN)
+	}
+
+	var stagingV, pointsV float64
+	if err := c.Conn().QueryRow(ctx,
+		"SELECT sum(metrics['v']) FROM clustopher.staging_points WHERE cluster_id = ?", clusterID).Scan(&stagingV); err != nil {
+		t.Fatalf("sum staging metric: %v", err)
+	}
+	if err := c.Conn().QueryRow(ctx,
+		"SELECT sum(metrics['v']) FROM clustopher.points WHERE cluster_id = ?", clusterID).Scan(&pointsV); err != nil {
+		t.Fatalf("sum points metric: %v", err)
+	}
+	if pointsV != stagingV {
+		t.Fatalf("canonical metric sum = %f, staging metric sum = %f", pointsV, stagingV)
+	}
+
+	bounds := KDBounds{MinX: -74.1, MinY: 40.6, MaxX: -73.9, MaxY: 40.8}
+	leafIdxs := make([]int32, len(sc.Skeleton.Leaves))
+	for i := range leafIdxs {
+		leafIdxs[i] = int32(i)
+	}
+	treeClusters, skipped, err := sc.aggregateLeaves(ctx, leafIdxs)
+	if err != nil {
+		t.Fatalf("aggregateLeaves: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("aggregateLeaves skipped %d leaves", len(skipped))
+	}
+	var treeTotal uint64
+	var treeV float64
+	for _, c := range treeClusters {
+		treeTotal += uint64(c.Count)
+		treeV += float64(c.Metrics["v"]) * float64(c.Count)
+	}
+	if treeTotal != stagingN {
+		t.Fatalf("aggregate leaf total = %d, staging count = %d", treeTotal, stagingN)
+	}
+	if treeV != stagingV {
+		t.Fatalf("aggregate leaf weighted v sum = %f, staging v sum = %f", treeV, stagingV)
+	}
+
+	clusters, err := sc.queryRollup(ctx, bounds, 8)
+	if err != nil {
+		t.Fatalf("queryRollup: %v", err)
+	}
+	var rollupTotal uint64
+	for _, c := range clusters {
+		rollupTotal += uint64(c.Count)
+	}
+	if rollupTotal != stagingN {
+		t.Fatalf("rollup total = %d, staging count = %d", rollupTotal, stagingN)
+	}
 }
 
 func TestInsertPoints_TriggersRollupMVs(t *testing.T) {

--- a/cluster/ch_load.go
+++ b/cluster/ch_load.go
@@ -1,0 +1,291 @@
+package cluster
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"runtime"
+	"strconv"
+	"sync"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+const (
+	chFirstProjectChunkSize = 250_000
+	idMapBatchSize          = 500_000
+	idMapInsertWorkers      = 4
+)
+
+type chSpatialRow struct {
+	ExternalID uint32
+	X          float32
+	Y          float32
+}
+
+// LoadFromCHStaging builds the exact same KD leaf order as Load, but reads only
+// compact spatial columns from clustopher.staging_points. It writes the
+// external->internal id map back to ClickHouse, then lets ClickHouse populate
+// clustopher.points from staging so metrics/metadata never enter Go's hot
+// clustering path.
+func (sc *Supercluster) LoadFromCHStaging(ctx context.Context) error {
+	if sc.ch == nil {
+		return fmt.Errorf("LoadFromCHStaging requires CH client")
+	}
+	if sc.clusterID == "" {
+		return fmt.Errorf("LoadFromCHStaging requires clusterID")
+	}
+
+	spatial, err := sc.readStagingSpatial(ctx)
+	if err != nil {
+		return err
+	}
+
+	projected := sc.projectStagingSpatial(spatial)
+
+	sorted := SortPointsIntoLeafOrderParallel(projected, sc.Options.NodeSize)
+	tree, remap := BuildSkeletonWithRemap(sorted, sc.Options.NodeSize)
+	sc.Skeleton = tree
+
+	loadID, err := newLoadID()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = sc.dropPointIDMapLoad(context.Background(), loadID)
+	}()
+
+	if err := sc.resetCanonicalCluster(ctx); err != nil {
+		return err
+	}
+	if err := sc.writePointIDMap(ctx, loadID, sorted, remap, spatial); err != nil {
+		return err
+	}
+	if err := sc.populatePointsFromStaging(ctx, loadID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sc *Supercluster) projectStagingSpatial(spatial []chSpatialRow) []KDPoint {
+	projected := make([]KDPoint, len(spatial))
+	workers := runtime.GOMAXPROCS(0)
+	if workers <= 1 || len(spatial) < chFirstProjectChunkSize {
+		for i, p := range spatial {
+			proj := sc.projectFast(p.X, p.Y, sc.Options.MaxZoom)
+			projected[i] = KDPoint{ID: uint32(i), X: proj[0], Y: proj[1], NumPoints: 1}
+		}
+		return projected
+	}
+
+	chunks := (len(spatial) + chFirstProjectChunkSize - 1) / chFirstProjectChunkSize
+	if workers > chunks {
+		workers = chunks
+	}
+
+	var wg sync.WaitGroup
+	jobs := make(chan int, chunks)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for start := range jobs {
+				end := start + chFirstProjectChunkSize
+				if end > len(spatial) {
+					end = len(spatial)
+				}
+				for i := start; i < end; i++ {
+					p := spatial[i]
+					proj := sc.projectFast(p.X, p.Y, sc.Options.MaxZoom)
+					projected[i] = KDPoint{ID: uint32(i), X: proj[0], Y: proj[1], NumPoints: 1}
+				}
+			}
+		}()
+	}
+	for start := 0; start < len(spatial); start += chFirstProjectChunkSize {
+		jobs <- start
+	}
+	close(jobs)
+	wg.Wait()
+	return projected
+}
+
+func (sc *Supercluster) readStagingSpatial(ctx context.Context) ([]chSpatialRow, error) {
+	var n uint64
+	if err := sc.ch.Conn().QueryRow(ctx,
+		"SELECT count() FROM clustopher.staging_points WHERE cluster_id = ?", sc.clusterID).Scan(&n); err != nil {
+		return nil, fmt.Errorf("count staging spatial: %w", err)
+	}
+	if n > uint64(int(^uint(0)>>1)) {
+		return nil, fmt.Errorf("staging spatial count %d exceeds max int", n)
+	}
+
+	rows, err := sc.ch.Conn().Query(ctx, `
+        SELECT external_id, x, y
+        FROM clustopher.staging_points
+        WHERE cluster_id = ?
+        ORDER BY external_id
+    `, sc.clusterID)
+	if err != nil {
+		return nil, fmt.Errorf("query staging spatial: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]chSpatialRow, 0, int(n))
+	for rows.Next() {
+		var row chSpatialRow
+		if err := rows.Scan(&row.ExternalID, &row.X, &row.Y); err != nil {
+			return nil, fmt.Errorf("scan staging spatial: %w", err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("staging spatial rows: %w", err)
+	}
+	return out, nil
+}
+
+func (sc *Supercluster) resetCanonicalCluster(ctx context.Context) error {
+	if err := sc.ch.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", sc.clusterID); err != nil {
+		return fmt.Errorf("drop points partition: %w", err)
+	}
+	for z := 2; z <= 16; z++ {
+		if err := sc.ch.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", sc.clusterID); err != nil {
+			return fmt.Errorf("drop rollup_z%d partition: %w", z, err)
+		}
+	}
+	return nil
+}
+
+func (sc *Supercluster) dropPointIDMapLoad(ctx context.Context, loadID uint64) error {
+	if err := sc.ch.Conn().Exec(ctx, "ALTER TABLE clustopher.point_id_map_load DROP PARTITION ?", loadID); err != nil {
+		return fmt.Errorf("drop id map load partition: %w", err)
+	}
+	return nil
+}
+
+func (sc *Supercluster) writePointIDMap(ctx context.Context, loadID uint64, sorted []KDPoint, remap []uint32, spatial []chSpatialRow) error {
+	chunks := (len(sorted) + idMapBatchSize - 1) / idMapBatchSize
+	workers := idMapInsertWorkers
+	if workers > chunks {
+		workers = chunks
+	}
+	if workers < 1 {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	jobs := make(chan int, chunks)
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			ch := sc.ch
+			if worker > 0 {
+				clone, err := sc.ch.Clone(ctx)
+				if err != nil {
+					errCh <- err
+					cancel()
+					return
+				}
+				defer clone.Close()
+				ch = clone
+			}
+			for start := range jobs {
+				if err := sc.writePointIDMapBatch(ctx, ch, loadID, sorted, remap, spatial, start); err != nil {
+					errCh <- err
+					cancel()
+					return
+				}
+			}
+		}(worker)
+	}
+
+sendJobs:
+	for start := 0; start < len(sorted); start += idMapBatchSize {
+		select {
+		case jobs <- start:
+		case <-ctx.Done():
+			break sendJobs
+		}
+	}
+	close(jobs)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
+	if err := ctx.Err(); err != nil && err != context.Canceled {
+		return err
+	}
+	return nil
+}
+
+func (sc *Supercluster) writePointIDMapBatch(ctx context.Context, ch *CHClient, loadID uint64, sorted []KDPoint, remap []uint32, spatial []chSpatialRow, start int) error {
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(insertSettings))
+	end := start + idMapBatchSize
+	if end > len(sorted) {
+		end = len(sorted)
+	}
+	batch, err := ch.Conn().PrepareBatch(ctx,
+		"INSERT INTO clustopher.point_id_map_load (load_id, external_id, internal_id)")
+	if err != nil {
+		return fmt.Errorf("prepare id map batch: %w", err)
+	}
+	for i := start; i < end; i++ {
+		origIdx := remap[i]
+		if int(origIdx) >= len(spatial) {
+			return fmt.Errorf("remap index %d out of range %d", origIdx, len(spatial))
+		}
+		if err := batch.Append(loadID, spatial[origIdx].ExternalID, sorted[i].ID); err != nil {
+			return fmt.Errorf("append id map row %d: %w", i, err)
+		}
+	}
+	if err := batch.Send(); err != nil {
+		return fmt.Errorf("send id map batch: %w", err)
+	}
+	return nil
+}
+
+func (sc *Supercluster) populatePointsFromStaging(ctx context.Context, loadID uint64) error {
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(insertSettings))
+	if err := sc.ch.Conn().Exec(ctx, `
+        INSERT INTO clustopher.points (cluster_id, id, external_id, x, y, metrics, metadata)
+        SELECT
+            s.cluster_id,
+            m.internal_id AS id,
+            s.external_id,
+            s.x,
+            s.y,
+            s.metrics,
+            s.metadata
+        FROM clustopher.staging_points AS s
+        INNER JOIN clustopher.point_id_map_load AS m
+            ON s.external_id = m.external_id
+        WHERE s.cluster_id = ?
+          AND m.load_id = ?
+        ORDER BY m.internal_id
+    `, sc.clusterID, loadID); err != nil {
+		return fmt.Errorf("populate points from staging: %w", err)
+	}
+	return nil
+}
+
+func newLoadID() (uint64, error) {
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return 0, fmt.Errorf("generate load id: %w", err)
+	}
+	id := binary.LittleEndian.Uint64(buf[:])
+	if id == 0 {
+		id = 1
+	}
+	return id, nil
+}

--- a/cluster/ch_load.go
+++ b/cluster/ch_load.go
@@ -44,7 +44,8 @@ func (sc *Supercluster) LoadFromCHStaging(ctx context.Context) error {
 
 	projected := sc.projectStagingSpatial(spatial)
 
-	sorted := SortPointsIntoLeafOrderParallel(projected, sc.Options.NodeSize)
+	sorted := SortPointsIntoLeafOrderParallelInPlace(projected, sc.Options.NodeSize)
+	projected = nil
 	tree, remap := BuildSkeletonWithRemap(sorted, sc.Options.NodeSize)
 	sc.Skeleton = tree
 
@@ -255,7 +256,19 @@ func (sc *Supercluster) writePointIDMapBatch(ctx context.Context, ch *CHClient, 
 }
 
 func (sc *Supercluster) populatePointsFromStaging(ctx context.Context, loadID uint64) error {
-	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(insertSettings))
+	// Merge insertSettings with merge-join settings so the staging x id_map join
+	// streams through sort-merge instead of building a full hash table on one
+	// side. At >100M rows a hash join needs 10-20 GB of CH server RAM; merge
+	// join keeps the working set bounded to a few hundred MB.
+	settings := clickhouse.Settings{}
+	for k, v := range insertSettings {
+		settings[k] = v
+	}
+	settings["join_algorithm"] = "full_sorting_merge"
+	settings["max_bytes_before_external_sort"] = uint64(8 * 1024 * 1024 * 1024)
+	settings["max_bytes_before_external_group_by"] = uint64(8 * 1024 * 1024 * 1024)
+
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(settings))
 	if err := sc.ch.Conn().Exec(ctx, `
         INSERT INTO clustopher.points (cluster_id, id, external_id, x, y, metrics, metadata)
         SELECT

--- a/cluster/ch_query.go
+++ b/cluster/ch_query.go
@@ -4,7 +4,16 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
+	"strings"
 )
+
+const maxLeafIDRangesPerQuery = 128
+
+type leafIDRange struct {
+	min uint32
+	max uint32
+}
 
 // queryRollup queries the per-zoom rollup table for the viewport.
 func (sc *Supercluster) queryRollup(ctx context.Context, viewport KDBounds, zoom int) ([]ClusterNode, error) {
@@ -38,11 +47,19 @@ func (sc *Supercluster) queryRollup(ctx context.Context, viewport KDBounds, zoom
 
 	table := fmt.Sprintf("clustopher.rollup_z%d", zoom)
 	q := fmt.Sprintf(`
-        SELECT tile_x, tile_y, cnt, sum_x, sum_y, metric_sums, metric_cnts
+        SELECT
+          tile_x,
+          tile_y,
+          sum(cnt) AS cnt,
+          sum(sum_x) AS sum_x,
+          sum(sum_y) AS sum_y,
+          sumMap(metric_sums) AS metric_sums,
+          sumMap(metric_cnts) AS metric_cnts
         FROM %s
         WHERE cluster_id = ?
           AND tile_x BETWEEN ? AND ?
           AND tile_y BETWEEN ? AND ?
+        GROUP BY tile_x, tile_y
     `, table)
 
 	rows, err := sc.ch.Conn().Query(ctx, q, sc.clusterID, minTX, maxTX, minTY, maxTY)
@@ -172,25 +189,31 @@ func (sc *Supercluster) queryTree(ctx context.Context, viewport KDBounds, zoom i
 }
 
 // aggregateLeaves emits one ClusterNode per inside leaf by aggregating across
-// each leaf's id range in CH. Uses intDiv(id-1, NodeSize) to map each point to
-// its leaf index — query string stays fixed-size regardless of leaf count.
-// Leaves whose point count falls below MinPoints are returned in skipped so the
-// caller can route them through the partial-leaf path (fetchLeafPoints +
-// clusterPoints) to avoid silently dropping their points.
+// each leaf's id range in CH. Leaves are compressed into contiguous internal-id
+// ranges so dense full-viewport queries do not serialize giant leaf arrays into
+// ClickHouse query text. Leaves whose point count falls below MinPoints are
+// returned in skipped so the caller can route them through the partial-leaf path
+// (fetchLeafPoints + clusterPoints) to avoid silently dropping their points.
 func (sc *Supercluster) aggregateLeaves(ctx context.Context, leaves []int32) (clusters []ClusterNode, skipped []int32, err error) {
 	if len(leaves) == 0 {
 		return nil, nil, nil
 	}
 
-	// Build an Array(UInt64) of the leaf indexes we care about.
-	// intDiv(id - 1, NodeSize) maps each point's id to its leaf index.
-	leafIdxArr := make([]uint64, len(leaves))
-	for i, li := range leaves {
-		leafIdxArr[i] = uint64(li)
+	ranges := sc.leafIDRanges(leaves)
+	if len(ranges) == 0 {
+		return nil, nil, nil
 	}
 	nodeSize := uint64(sc.Options.NodeSize)
 
-	q := fmt.Sprintf(`
+	out := make([]ClusterNode, 0, len(leaves))
+	var skip []int32
+	for start := 0; start < len(ranges); start += maxLeafIDRangesPerQuery {
+		end := start + maxLeafIDRangesPerQuery
+		if end > len(ranges) {
+			end = len(ranges)
+		}
+		where, rangeArgs := leafRangePredicate(ranges[start:end])
+		q := fmt.Sprintf(`
         SELECT
             toInt32(intDiv(id - 1, %d)) AS leaf_idx,
             count() AS cnt,
@@ -200,90 +223,154 @@ func (sc *Supercluster) aggregateLeaves(ctx context.Context, leaves []int32) (cl
             sumMap(mapFromArrays(mapKeys(metrics), arrayMap(v -> toUInt64(1), mapValues(metrics)))) AS mcnt
         FROM clustopher.points
         WHERE cluster_id = ?
-          AND has(?, intDiv(id - 1, %d))
+          AND (%s)
         GROUP BY leaf_idx
-    `, nodeSize, nodeSize)
+    `, nodeSize, where)
 
-	rows, err := sc.ch.Conn().Query(ctx, q, sc.clusterID, leafIdxArr)
-	if err != nil {
-		return nil, nil, fmt.Errorf("aggregate leaves: %w", err)
-	}
-	defer rows.Close()
+		args := make([]any, 0, 1+len(rangeArgs))
+		args = append(args, sc.clusterID)
+		args = append(args, rangeArgs...)
 
-	out := make([]ClusterNode, 0, len(leaves))
-	var skip []int32
-	var (
-		leafIdx int32
-		cnt     uint64
-		cx, cy  float64
-		msum    map[string]float64
-		mcnt    map[string]uint64
-	)
-	for rows.Next() {
-		if err := rows.Scan(&leafIdx, &cnt, &cx, &cy, &msum, &mcnt); err != nil {
-			return nil, nil, fmt.Errorf("scan agg row: %w", err)
+		rows, err := sc.ch.Conn().Query(ctx, q, args...)
+		if err != nil {
+			return nil, nil, fmt.Errorf("aggregate leaves: %w", err)
 		}
-		if cnt < uint64(sc.Options.MinPoints) {
-			skip = append(skip, leafIdx)
-			continue
-		}
-		metrics := make(map[string]float32, len(msum))
-		for k, s := range msum {
-			if n := mcnt[k]; n > 0 {
-				metrics[k] = float32(s / float64(n))
+		var (
+			leafIdx int32
+			cnt     uint64
+			cx, cy  float64
+			msum    map[string]float64
+			mcnt    map[string]uint64
+		)
+		for rows.Next() {
+			if err := rows.Scan(&leafIdx, &cnt, &cx, &cy, &msum, &mcnt); err != nil {
+				rows.Close()
+				return nil, nil, fmt.Errorf("scan agg row: %w", err)
 			}
+			if cnt < uint64(sc.Options.MinPoints) {
+				skip = append(skip, leafIdx)
+				continue
+			}
+			metrics := make(map[string]float32, len(msum))
+			for k, s := range msum {
+				if n := mcnt[k]; n > 0 {
+					metrics[k] = float32(s / float64(n))
+				}
+			}
+			out = append(out, ClusterNode{
+				ID:      uint32(leafIdx),
+				X:       float32(cx),
+				Y:       float32(cy),
+				Count:   uint32(cnt),
+				Metrics: metrics,
+			})
 		}
-		out = append(out, ClusterNode{
-			ID:      uint32(leafIdx),
-			X:       float32(cx),
-			Y:       float32(cy),
-			Count:   uint32(cnt),
-			Metrics: metrics,
-		})
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, nil, err
+		}
+		rows.Close()
 	}
-	return out, skip, rows.Err()
+	return out, skip, nil
 }
 
 // fetchLeafPoints fetches all points belonging to the given leaves and returns
 // them projected to the target zoom (so existing clusterPoints can run).
-// Uses intDiv(id-1, NodeSize) + has() to keep the query string fixed-size
-// regardless of leaf count, avoiding CH max_query_size limits.
+// Leaves are compressed into contiguous internal-id ranges to avoid serializing
+// large leaf arrays into ClickHouse query text.
 func (sc *Supercluster) fetchLeafPoints(ctx context.Context, leaves []int32, zoom int) ([]KDPoint, error) {
 	if len(leaves) == 0 {
 		return nil, nil
 	}
 
-	// Build an Array(UInt64) of the leaf indexes we care about.
-	// intDiv(id - 1, NodeSize) maps each point's id to its leaf index.
-	leafIdxArr := make([]uint64, len(leaves))
-	for i, li := range leaves {
-		leafIdxArr[i] = uint64(li)
+	ranges := sc.leafIDRanges(leaves)
+	if len(ranges) == 0 {
+		return nil, nil
 	}
-	nodeSize := uint64(sc.Options.NodeSize)
-
-	q := fmt.Sprintf(`
-        SELECT id, x, y FROM clustopher.points
-        WHERE cluster_id = ?
-          AND has(?, intDiv(id - 1, %d))
-    `, nodeSize)
-
-	rows, err := sc.ch.Conn().Query(ctx, q, sc.clusterID, leafIdxArr)
-	if err != nil {
-		return nil, fmt.Errorf("fetch leaf points: %w", err)
-	}
-	defer rows.Close()
 
 	out := make([]KDPoint, 0, len(leaves)*sc.Options.NodeSize)
-	var id uint32
-	var x, y float32
-	for rows.Next() {
-		if err := rows.Scan(&id, &x, &y); err != nil {
+	for start := 0; start < len(ranges); start += maxLeafIDRangesPerQuery {
+		end := start + maxLeafIDRangesPerQuery
+		if end > len(ranges) {
+			end = len(ranges)
+		}
+		where, rangeArgs := leafRangePredicate(ranges[start:end])
+		q := fmt.Sprintf(`
+        SELECT id, x, y FROM clustopher.points
+        WHERE cluster_id = ?
+          AND (%s)
+    `, where)
+
+		args := make([]any, 0, 1+len(rangeArgs))
+		args = append(args, sc.clusterID)
+		args = append(args, rangeArgs...)
+
+		rows, err := sc.ch.Conn().Query(ctx, q, args...)
+		if err != nil {
+			return nil, fmt.Errorf("fetch leaf points: %w", err)
+		}
+		var id uint32
+		var x, y float32
+		for rows.Next() {
+			if err := rows.Scan(&id, &x, &y); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			proj := sc.projectFast(x, y, zoom)
+			out = append(out, KDPoint{ID: id, X: proj[0], Y: proj[1], NumPoints: 1})
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
 			return nil, err
 		}
-		proj := sc.projectFast(x, y, zoom)
-		out = append(out, KDPoint{ID: id, X: proj[0], Y: proj[1], NumPoints: 1})
+		rows.Close()
 	}
-	return out, rows.Err()
+	return out, nil
+}
+
+func (sc *Supercluster) leafIDRanges(leaves []int32) []leafIDRange {
+	if len(leaves) == 0 || sc.Skeleton == nil {
+		return nil
+	}
+	sorted := make([]int32, 0, len(leaves))
+	for _, leafIdx := range leaves {
+		if leafIdx >= 0 && int(leafIdx) < len(sc.Skeleton.Leaves) {
+			sorted = append(sorted, leafIdx)
+		}
+	}
+	if len(sorted) == 0 {
+		return nil
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	ranges := make([]leafIDRange, 0, len(sorted))
+	for _, leafIdx := range sorted {
+		leaf := sc.Skeleton.Leaves[leafIdx]
+		next := leafIDRange{min: leaf.IDMin, max: leaf.IDMax}
+		if len(ranges) == 0 {
+			ranges = append(ranges, next)
+			continue
+		}
+		last := &ranges[len(ranges)-1]
+		if next.min <= last.max || (last.max < ^uint32(0) && next.min == last.max+1) {
+			if next.max > last.max {
+				last.max = next.max
+			}
+			continue
+		}
+		ranges = append(ranges, next)
+	}
+	return ranges
+}
+
+func leafRangePredicate(ranges []leafIDRange) (string, []any) {
+	parts := make([]string, len(ranges))
+	args := make([]any, 0, len(ranges)*2)
+	for i, r := range ranges {
+		parts[i] = "id BETWEEN ? AND ?"
+		args = append(args, r.min, r.max)
+	}
+	return strings.Join(parts, " OR "), args
 }
 
 // GetClustersCH is the CH-backed equivalent of GetClusters. Routes by zoom:

--- a/cluster/ch_query_test.go
+++ b/cluster/ch_query_test.go
@@ -9,6 +9,45 @@ import (
 	"testing"
 )
 
+func TestLeafIDRanges_MergesContiguousLeaves(t *testing.T) {
+	sc := &Supercluster{
+		Skeleton: &SkeletonTree{
+			Leaves: []SkeletonLeaf{
+				{IDMin: 1, IDMax: 64},
+				{IDMin: 65, IDMax: 128},
+				{IDMin: 129, IDMax: 192},
+				{IDMin: 257, IDMax: 320},
+			},
+		},
+	}
+
+	got := sc.leafIDRanges([]int32{3, 0, 1, 2})
+	if len(got) != 2 {
+		t.Fatalf("ranges len = %d, want 2: %+v", len(got), got)
+	}
+	if got[0] != (leafIDRange{min: 1, max: 192}) {
+		t.Fatalf("range 0 = %+v, want 1..192", got[0])
+	}
+	if got[1] != (leafIDRange{min: 257, max: 320}) {
+		t.Fatalf("range 1 = %+v, want 257..320", got[1])
+	}
+}
+
+func TestLeafRangePredicate_UsesBoundedBetweenClauses(t *testing.T) {
+	where, args := leafRangePredicate([]leafIDRange{
+		{min: 1, max: 64},
+		{min: 257, max: 320},
+	})
+
+	want := "id BETWEEN ? AND ? OR id BETWEEN ? AND ?"
+	if where != want {
+		t.Fatalf("where = %q, want %q", where, want)
+	}
+	if len(args) != 4 || args[0] != uint32(1) || args[1] != uint32(64) || args[2] != uint32(257) || args[3] != uint32(320) {
+		t.Fatalf("args = %#v", args)
+	}
+}
+
 func setupQueryFixture(t *testing.T, clusterID string, n int) *Supercluster {
 	t.Helper()
 	dsn := os.Getenv("CLICKHOUSE_DSN")

--- a/cluster/migrations/001_init.sql
+++ b/cluster/migrations/001_init.sql
@@ -12,3 +12,33 @@ CREATE TABLE IF NOT EXISTS clustopher.points (
 PARTITION BY cluster_id
 ORDER BY (cluster_id, id)
 SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS clustopher.staging_points (
+    cluster_id   String,
+    external_id  UInt32,
+    x            Float32,
+    y            Float32,
+    metrics      Map(String, Float32),
+    metadata     Map(String, String)
+) ENGINE = MergeTree
+PARTITION BY cluster_id
+ORDER BY (cluster_id, external_id)
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS clustopher.point_id_map (
+    cluster_id  String,
+    external_id UInt32,
+    internal_id UInt32
+) ENGINE = MergeTree
+PARTITION BY cluster_id
+ORDER BY (cluster_id, external_id)
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS clustopher.point_id_map_load (
+    load_id     UInt64,
+    external_id UInt32,
+    internal_id UInt32
+) ENGINE = MergeTree
+PARTITION BY load_id
+ORDER BY (load_id, external_id)
+SETTINGS index_granularity = 8192;

--- a/cluster/migrations_test.go
+++ b/cluster/migrations_test.go
@@ -38,14 +38,16 @@ func TestRunMigrations_CreatesTables(t *testing.T) {
 		t.Fatalf("RunMigrations: %v", err)
 	}
 
-	var n uint64
-	row := conn.QueryRow(context.Background(),
-		"SELECT count() FROM system.tables WHERE database='clustopher' AND name='points'")
-	if err := row.Scan(&n); err != nil {
-		t.Fatalf("scan: %v", err)
-	}
-	if n != 1 {
-		t.Fatalf("expected points table to exist, got count=%d", n)
+	for _, table := range []string{"points", "staging_points", "point_id_map", "point_id_map_load"} {
+		var n uint64
+		row := conn.QueryRow(context.Background(),
+			"SELECT count() FROM system.tables WHERE database='clustopher' AND name=?", table)
+		if err := row.Scan(&n); err != nil {
+			t.Fatalf("scan %s: %v", table, err)
+		}
+		if n != 1 {
+			t.Fatalf("expected %s table to exist, got count=%d", table, n)
+		}
 	}
 
 	for z := 2; z <= 16; z++ {

--- a/cluster/skeleton.go
+++ b/cluster/skeleton.go
@@ -1,5 +1,12 @@
 package cluster
 
+import (
+	"runtime"
+	"sync"
+)
+
+const parallelSortThreshold = 1_000_000
+
 // SkeletonLeaf is a tree leaf that retains only a bounding box, contiguous
 // internal-id range, and point count. The actual point data lives in
 // ClickHouse (or, during Phase 1, in the existing in-memory point store).
@@ -144,6 +151,71 @@ func SortPointsIntoLeafOrder(points []KDPoint, nodeSize int) []KDPoint {
 	out := make([]KDPoint, len(points))
 	copy(out, points)
 	sortRecursive(out, 0, len(out)-1, 0, nodeSize)
+	return out
+}
+
+func SortPointsIntoLeafOrderParallel(points []KDPoint, nodeSize int) []KDPoint {
+	return sortPointsIntoLeafOrderParallel(points, nodeSize, parallelSortThreshold)
+}
+
+func sortPointsIntoLeafOrderParallel(points []KDPoint, nodeSize, threshold int) []KDPoint {
+	if nodeSize < 1 {
+		nodeSize = 1
+	}
+	if threshold < 1 {
+		threshold = 1
+	}
+	out := make([]KDPoint, len(points))
+	copy(out, points)
+	if len(out) == 0 {
+		return out
+	}
+
+	workers := runtime.GOMAXPROCS(0)
+	if workers <= 1 || len(out) < threshold {
+		sortRecursive(out, 0, len(out)-1, 0, nodeSize)
+		return out
+	}
+
+	tokens := make(chan struct{}, workers-1)
+	var wg sync.WaitGroup
+	var sortParallel func(lo, hi, axis int)
+
+	run := func(lo, hi, axis int) {
+		if hi-lo+1 < threshold {
+			sortParallel(lo, hi, axis)
+			return
+		}
+		select {
+		case tokens <- struct{}{}:
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() { <-tokens }()
+				sortParallel(lo, hi, axis)
+			}()
+		default:
+			sortParallel(lo, hi, axis)
+		}
+	}
+
+	sortParallel = func(lo, hi, axis int) {
+		if hi-lo+1 <= nodeSize {
+			return
+		}
+		mid := (lo + hi) / 2
+		if axis == 0 {
+			quickselectX(out, lo, hi, mid)
+		} else {
+			quickselectY(out, lo, hi, mid)
+		}
+		nextAxis := axis ^ 1
+		run(lo, mid-1, nextAxis)
+		run(mid+1, hi, nextAxis)
+	}
+
+	sortParallel(0, len(out)-1, 0)
+	wg.Wait()
 	return out
 }
 

--- a/cluster/skeleton.go
+++ b/cluster/skeleton.go
@@ -155,18 +155,30 @@ func SortPointsIntoLeafOrder(points []KDPoint, nodeSize int) []KDPoint {
 }
 
 func SortPointsIntoLeafOrderParallel(points []KDPoint, nodeSize int) []KDPoint {
-	return sortPointsIntoLeafOrderParallel(points, nodeSize, parallelSortThreshold)
+	return sortPointsIntoLeafOrderParallel(points, nodeSize, parallelSortThreshold, true)
 }
 
-func sortPointsIntoLeafOrderParallel(points []KDPoint, nodeSize, threshold int) []KDPoint {
+// SortPointsIntoLeafOrderParallelInPlace mutates the input slice in place and
+// returns it. Skips the full-slice copy that SortPointsIntoLeafOrderParallel
+// makes for safety, halving peak heap on multi-hundred-million-point loads.
+func SortPointsIntoLeafOrderParallelInPlace(points []KDPoint, nodeSize int) []KDPoint {
+	return sortPointsIntoLeafOrderParallel(points, nodeSize, parallelSortThreshold, false)
+}
+
+func sortPointsIntoLeafOrderParallel(points []KDPoint, nodeSize, threshold int, copyInput bool) []KDPoint {
 	if nodeSize < 1 {
 		nodeSize = 1
 	}
 	if threshold < 1 {
 		threshold = 1
 	}
-	out := make([]KDPoint, len(points))
-	copy(out, points)
+	var out []KDPoint
+	if copyInput {
+		out = make([]KDPoint, len(points))
+		copy(out, points)
+	} else {
+		out = points
+	}
 	if len(out) == 0 {
 		return out
 	}

--- a/cluster/skeleton_test.go
+++ b/cluster/skeleton_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"runtime"
 	"testing"
 	"unsafe"
 )
@@ -69,6 +70,28 @@ func TestSortPointsIntoLeafOrder_DeterministicLeaves(t *testing.T) {
 		area := (leafBounds.MaxX - leafBounds.MinX) * (leafBounds.MaxY - leafBounds.MinY)
 		if area > 0.5*fullArea {
 			t.Errorf("leaf %d covers >50%% of full bbox (area=%f, full=%f)", i/2, area, fullArea)
+		}
+	}
+}
+
+func TestSortPointsIntoLeafOrderParallel_MatchesSequential(t *testing.T) {
+	prev := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(prev)
+
+	pts := make([]KDPoint, 4096)
+	for i := range pts {
+		pts[i] = KDPoint{
+			ID: uint32(i + 1),
+			X:  float32((i*7919)%10007) / 10007,
+			Y:  float32((i*1543)%10009) / 10009,
+		}
+	}
+
+	want := SortPointsIntoLeafOrder(pts, 16)
+	got := sortPointsIntoLeafOrderParallel(pts, 16, 64)
+	for i := range want {
+		if got[i].ID != want[i].ID {
+			t.Fatalf("point %d id = %d, want %d", i, got[i].ID, want[i].ID)
 		}
 	}
 }

--- a/cluster/skeleton_test.go
+++ b/cluster/skeleton_test.go
@@ -88,7 +88,7 @@ func TestSortPointsIntoLeafOrderParallel_MatchesSequential(t *testing.T) {
 	}
 
 	want := SortPointsIntoLeafOrder(pts, 16)
-	got := sortPointsIntoLeafOrderParallel(pts, 16, 64)
+	got := sortPointsIntoLeafOrderParallel(pts, 16, 64, true)
 	for i := range want {
 		if got[i].ID != want[i].ID {
 			t.Fatalf("point %d id = %d, want %d", i, got[i].ID, want[i].ID)

--- a/cluster/z14_probe_test.go
+++ b/cluster/z14_probe_test.go
@@ -1,0 +1,118 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestZ14Probe(t *testing.T) {
+	if os.Getenv("Z14_PROBE") != "1" {
+		t.Skip("set Z14_PROBE=1")
+	}
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("no DSN")
+	}
+
+	nStr := os.Getenv("PROBE_N")
+	if nStr == "" {
+		nStr = "30000000"
+	}
+	n, _ := strconv.Atoi(nStr)
+
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		t.Fatal(err)
+	}
+
+	cid := fmt.Sprintf("Z14_PROBE_%d", n)
+	conus := KDBounds{MinX: -125, MinY: 25, MaxX: -65, MaxY: 49}
+	city := KDBounds{MinX: -100.25, MinY: 39.25, MaxX: -99.75, MaxY: 39.75}
+
+	cleanup := func() {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", cid)
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", cid)
+		for z := 2; z <= 16; z++ {
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", cid)
+		}
+	}
+	cleanup()
+
+	t.Logf("staging gen N=%d", n)
+	start := time.Now()
+	if err := generateDenseStagingPoints(ctx, c, cid, n, conus); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("staged in %s", time.Since(start))
+
+	sc := NewSupercluster(SuperclusterOptions{
+		MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40, Extent: 512, NodeSize: 64,
+	})
+	sc.SetCHClient(c)
+	sc.SetClusterID(cid)
+
+	start = time.Now()
+	if err := sc.LoadFromCHStaging(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("loaded in %s, leaves=%d", time.Since(start), len(sc.Skeleton.Leaves))
+
+	// Probe 1: project city viewport to skeleton space.
+	tl := sc.projectFast(city.MinX, city.MaxY, 16)
+	br := sc.projectFast(city.MaxX, city.MinY, 16)
+	vp := KDBounds{MinX: tl[0], MinY: tl[1], MaxX: br[0], MaxY: br[1]}
+	t.Logf("city vp lnglat: %+v", city)
+	t.Logf("city vp projected: %+v", vp)
+
+	// Probe 2: count overlapping leaves.
+	idxs := sc.Skeleton.RangeLeaves(vp)
+	t.Logf("overlapping leaves: %d", len(idxs))
+	if len(idxs) > 0 {
+		t.Logf("first 3 leaves:")
+		for i, idx := range idxs {
+			if i >= 3 {
+				break
+			}
+			lf := sc.Skeleton.Leaves[idx]
+			t.Logf("  leaf[%d] count=%d bounds=%+v idmin=%d idmax=%d", idx, lf.Count, lf.Bounds, lf.IDMin, lf.IDMax)
+		}
+	}
+
+	// Probe 3: CH-side: points inside city viewport.
+	var chCount uint64
+	if err := c.Conn().QueryRow(ctx,
+		"SELECT count() FROM clustopher.points WHERE cluster_id = ? AND x BETWEEN ? AND ? AND y BETWEEN ? AND ?",
+		cid, city.MinX, city.MaxX, city.MinY, city.MaxY).Scan(&chCount); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("CH points in city viewport: %d", chCount)
+
+	// Probe 4: actual GetClustersCH at z=14.
+	clusters, err := sc.GetClustersCH(ctx, city, 14)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("GetClustersCH z=14 clusters=%d", len(clusters))
+	for i, cl := range clusters {
+		if i >= 3 {
+			break
+		}
+		t.Logf("  cl[%d] count=%d x=%f y=%f", i, cl.Count, cl.X, cl.Y)
+	}
+
+	// Probe 5: root node + skeleton overall bounds.
+	if n := len(sc.Skeleton.Nodes); n > 0 {
+		root := sc.Skeleton.Nodes[n-1]
+		t.Logf("root node bounds: %+v leafIdx=%d L=%d R=%d", root.Bounds, root.LeafIdx, root.Left, root.Right)
+		t.Logf("total nodes=%d total leaves=%d", n, len(sc.Skeleton.Leaves))
+	}
+}


### PR DESCRIPTION
## Summary
- add a CH-first staging load path that builds the skeleton from compact spatial rows and populates canonical points from staging
- add staging/scratch map tables plus tests that compare canonical output against staging source data
- compress leaf fetch predicates into id ranges and add dense NYC / western hemisphere perf benchmarks with profiling hooks
- add bounded parallel projection, KD leaf ordering, and scratch ID-map inserts

## Validation
- go test ./...
- CLICKHOUSE_DSN=clickhouse://default:@127.0.0.1:19000/clustopher go test ./cluster -count=1
- profiled BenchmarkClusteringCHFirstDenseNYC_15M and BenchmarkClusteringCHFirstWesternHemisphere_15M locally