### PR TITLE
Streaming Morton load + scale to 1B + UI metadata fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,39 +126,36 @@ CLICKHOUSE_DSN=clickhouse://default:@localhost:9000/clustopher_test go test ./..
 
 Measured on AMD Ryzen 9 5900X (24 threads), single-node ClickHouse 24.8 in Docker, random points uniformly distributed across the CONUS bounding box. Viewports are zoom-appropriate (continental at low zoom, state at mid zoom, city at high zoom):
 
-Two load paths are exercised:
-
-- **`LoadFromCHStaging`** (default for ≤300 M): materializes the full `[]KDPoint` slice in Go and runs an exact KD-tree median-partition sort. Tight leaf bounds, best high-zoom query latency, but Go heap grows linearly with point count.
-- **`LoadFromCHStreaming`** (used for 500 M and 1 B rows here): pushes the spatial sort into ClickHouse via a Morton-encoded `ORDER BY`, streams the sorted rows back in `NodeSize` chunks, and builds skeleton leaves on the fly. Go heap is bounded (≈ 1.6 GB at 1 B points). Morton leaves are slightly looser than KD leaves, so high-zoom queries return a few % more raw points at viewport edges.
+All sizes are measured against `LoadFromCHStreaming`, which pushes the spatial sort into ClickHouse via a Morton-encoded `ORDER BY`, streams the sorted rows back in `NodeSize` chunks, and builds skeleton leaves on the fly. Go heap is bounded by the skeleton tree alone (≈ 1.6 GB at 1 B points). An alternative `LoadFromCHStaging` path runs an exact KD-tree median-partition sort in Go — slightly tighter leaf bounds and better high-zoom latency, but heap grows linearly so it tops out around 300 M on this box.
 
 #### Scale (load + storage)
 
-| Points | Path | CH stage gen | Load (skeleton + canonical points) | Rollup OPTIMIZE FINAL | Resident heap after load | Skeleton leaves |
-|--------|------|-------------:|-----------------------------------:|----------------------:|-------------------------:|----------------:|
-|   5 M  | KD     |   0.7 s |    9.2 s |   17.1 s |   18 MB |  78 K |
-|  15 M  | KD     |   1.8 s |   28.6 s |   43.8 s |   33 MB | 234 K |
-|  50 M  | KD     |   6.3 s |  103.1 s |  117.6 s |   83 MB | 781 K |
-| 100 M  | KD     |  12.2 s |  216.4 s |  212.5 s |  176 MB | 1.5 M |
-| 200 M  | KD     |  26.2 s |  536.2 s |  444.2 s |  334 MB | 3.1 M |
-| 300 M  | KD     |  45.3 s |  833.7 s |  569.0 s |  444 MB | 4.7 M |
-| 500 M  | Morton |  65.4 s | 1 328.0 s |  744.4 s |  810 MB | 7.8 M |
-| **1 B** | **Morton** | **178.5 s** | **2 747.3 s** | **7.4 s** | **1 580 MB** | **15.6 M** |
+| Points | CH stage gen | Load (skeleton + canonical points) | Rollup OPTIMIZE FINAL | Resident heap after load | Skeleton leaves |
+|--------|-------------:|-----------------------------------:|----------------------:|-------------------------:|----------------:|
+|   5 M  |   1.0 s |    13.5 s |   4.3 s |   10 MB |  78 K |
+|  15 M  |   2.1 s |    38.6 s |   4.7 s |   28 MB | 234 K |
+|  50 M  |   6.4 s |   131.4 s |   5.6 s |   74 MB | 781 K |
+| 100 M  |  12.8 s |   255.7 s |   5.8 s |  174 MB | 1.5 M |
+| 200 M  |  26.4 s |   538.4 s |   8.1 s |  336 MB | 3.1 M |
+| 300 M  |  40.8 s |   799.0 s |   7.6 s |  418 MB | 4.7 M |
+| 500 M  |  69.4 s | 1 320.1 s |   6.2 s |  812 MB | 7.8 M |
+| **1 B** | **178.5 s** | **2 747.3 s** | **7.4 s** | **1 580 MB** | **15.6 M** |
 
 Resident heap is what the skeleton tree pins after `Load…` returns + GC. Raw points live in ClickHouse; Go holds only the bounds-only leaf index. Rollup `OPTIMIZE FINAL` collapses per-insert parts into a single sorted run per zoom partition — needed once after bulk load so the rollup path scans contiguous data.
 
-Rollup MVs are only created for zooms `[MinRollupZoom..MaxRollupZoom]` (currently 2–10), because the routing cutoff `ZSplit=11` means zooms 11+ are answered by the in-memory skeleton tree, never by the rollup path. Dropping the z11–z16 MVs at 1 B points cuts Load wall-clock 46% (less write-amplification on insert) and `OPTIMIZE FINAL` 99.7% (z11–z16 would have held ~1 B rollup rows because their tile grids approach point count at high zoom).
+Rollup MVs are only created for zooms `[MinRollupZoom..MaxRollupZoom]` (currently 2–10), because the routing cutoff `ZSplit=11` means zooms 11+ are answered by the in-memory skeleton tree, never by the rollup path. Dropping the z11–z16 MVs cuts both incremental Load wall-clock (fewer MVs to fan to per insert block) and `OPTIMIZE FINAL` from minutes to single-digit seconds at every dataset size measured.
 
 #### Query latency (`GetClustersCH`, 5-iter warm avg)
 
 | Points | z2 / CONUS 60°×24° | z8 / state 5°×5° | z14 / city 0.5°×0.5° | z14 clusters returned | z14 alloc/op |
 |--------|-------------------:|-----------------:|---------------------:|----------------------:|-------------:|
-|   5 M  |  **2.9 ms** | **10.5 ms** |   **3.3 ms** |   1 600 |  0.48 MB |
-|  15 M  |  **5.5 ms** | **12.9 ms** |   **6.6 ms** |   3 772 |  1.33 MB |
-|  50 M  |  **3.7 ms** | **10.4 ms** |  **13.3 ms** |  11 395 |  4.20 MB |
-| 100 M  |  **3.6 ms** | **10.2 ms** |  **29.0 ms** |  20 795 |  8.80 MB |
-| 200 M  |  **3.5 ms** | **14.9 ms** |  **69.1 ms** |  34 408 | 15.07 MB |
-| 300 M  |  **3.7 ms** | **16.5 ms** | **136.8 ms** |  44 683 | 20.46 MB |
-| 500 M  |  **3.4 ms** | **10.7 ms** | **270.9 ms** |  59 064 | 28.45 MB |
+|   5 M  |  **3.7 ms** | **11.8 ms** |   **13.4 ms** |   2 112 |   4.39 MB |
+|  15 M  |  **3.5 ms** | **11.1 ms** |   **19.8 ms** |   4 792 |  10.09 MB |
+|  50 M  |  **4.9 ms** | **15.1 ms** |   **46.2 ms** |  12 529 |  26.87 MB |
+| 100 M  |  **4.7 ms** | **11.8 ms** |   **75.4 ms** |  21 539 |  47.00 MB |
+| 200 M  |  **4.2 ms** | **12.1 ms** |  **155.2 ms** |  36 636 |  83.62 MB |
+| 300 M  |  **4.0 ms** | **13.0 ms** |  **269.2 ms** |  47 373 | 115.90 MB |
+| 500 M  |  **5.3 ms** | **13.0 ms** |  **508.8 ms** |  59 064 | 163.22 MB |
 | **1 B** |  **4.3 ms** | **14.2 ms** | **1 000.3 ms** |  68 986 | 262.08 MB |
 
 z2 and z8 (`zoom < ZSplit`, default 11) hit the per-zoom rollup materialized views in ClickHouse: latency is flat across the entire 200× size range because the rollup-row count is bounded by the zoom-tile grid, not the underlying point count.
@@ -177,13 +174,13 @@ Tradeoff: Morton leaves are slightly looser than KD leaves (about 15 % more poin
 
 | Zoom | Old (full bbox, in-memory KD-tree) | New (zoom-appropriate viewport, CH-backed) | Speedup |
 |------|-----------------------------------:|-------------------------------------------:|--------:|
-| 2    | 30.35 s | 5.5 ms |  ~5 500× |
-| 8    | 18.19 s | 12.9 ms |  ~1 400× |
-| 14   | 67.42 s | 6.6 ms | ~10 200× |
+| 2    | 30.35 s | 3.5 ms |  ~8 700× |
+| 8    | 18.19 s | 11.1 ms |  ~1 600× |
+| 14   | 67.42 s | 19.8 ms | ~3 400× |
 
 Columns are not strictly apples-to-apples — the old benchmarks always queried the full CONUS bbox, unrealistic at z14 where a real viewport is one neighborhood. With zoom-appropriate viewports the new system stays interactive across the entire zoom range, and now scales to ~67× the point count of the old in-memory system (1 B vs ~15 M before the heap blew up).
 
-Raw results: `benchmark_results/scale_full_rerun.txt`, `benchmark_results/scale_streaming_500M.txt`, `benchmark_results/scale_streaming_1B.txt`, `benchmark_results/baseline_15M.txt`.
+Raw results: `benchmark_results/scale_streaming_full_v3.txt`, `benchmark_results/scale_streaming_1B_v3.txt`, `benchmark_results/baseline_15M.txt`.
 
 ### Limitations
 - Single-node ClickHouse only; no distributed CH support

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The motivation was a pure in-memory predecessor (KD-tree + grid clustering + zst
 - Bounds-only skeleton KD-tree in Go for fast spatial pruning at high zoom levels
 - ClickHouse materialized-view rollups for low-zoom aggregation
 - Dynamic routing between rollup and skeleton paths based on zoom level (`ZSplit`, default 11)
-- Verified at 300 M points with sub-20 ms low/mid-zoom queries and 137 ms at z14 city viewport on a single box
+- Verified at **1 billion** points on a single box (94 GB RAM, single-node CH 24.8) with sub-15 ms low/mid-zoom queries via a Morton-sorted streaming load path
 
 ### Metrics & Metadata
 - Support for arbitrary numeric metrics on points
@@ -126,18 +126,25 @@ CLICKHOUSE_DSN=clickhouse://default:@localhost:9000/clustopher_test go test ./..
 
 Measured on AMD Ryzen 9 5900X (24 threads), single-node ClickHouse 24.8 in Docker, random points uniformly distributed across the CONUS bounding box. Viewports are zoom-appropriate (continental at low zoom, state at mid zoom, city at high zoom):
 
+Two load paths are exercised:
+
+- **`LoadFromCHStaging`** (default for ≤300 M): materializes the full `[]KDPoint` slice in Go and runs an exact KD-tree median-partition sort. Tight leaf bounds, best high-zoom query latency, but Go heap grows linearly with point count.
+- **`LoadFromCHStreaming`** (used for 500 M and 1 B rows here): pushes the spatial sort into ClickHouse via a Morton-encoded `ORDER BY`, streams the sorted rows back in `NodeSize` chunks, and builds skeleton leaves on the fly. Go heap is bounded (≈ 1.6 GB at 1 B points). Morton leaves are slightly looser than KD leaves, so high-zoom queries return a few % more raw points at viewport edges.
+
 #### Scale (load + storage)
 
-| Points | CH stage gen | Load (skeleton + canonical points) | Rollup OPTIMIZE FINAL | Resident heap after load | Skeleton leaves |
-|--------|-------------:|-----------------------------------:|----------------------:|-------------------------:|----------------:|
-|   5 M  |   0.7 s |    9.2 s |   17.1 s |   18 MB |  78 K |
-|  15 M  |   1.8 s |   28.6 s |   43.8 s |   33 MB | 234 K |
-|  50 M  |   6.3 s |  103.1 s |  117.6 s |   83 MB | 781 K |
-| 100 M  |  12.2 s |  216.4 s |  212.5 s |  176 MB | 1.5 M |
-| 200 M  |  26.2 s |  536.2 s |  444.2 s |  334 MB | 3.1 M |
-| 300 M  |  45.3 s |  833.7 s |  569.0 s |  444 MB | 4.7 M |
+| Points | Path | CH stage gen | Load (skeleton + canonical points) | Rollup OPTIMIZE FINAL | Resident heap after load | Skeleton leaves |
+|--------|------|-------------:|-----------------------------------:|----------------------:|-------------------------:|----------------:|
+|   5 M  | KD     |   0.7 s |    9.2 s |   17.1 s |   18 MB |  78 K |
+|  15 M  | KD     |   1.8 s |   28.6 s |   43.8 s |   33 MB | 234 K |
+|  50 M  | KD     |   6.3 s |  103.1 s |  117.6 s |   83 MB | 781 K |
+| 100 M  | KD     |  12.2 s |  216.4 s |  212.5 s |  176 MB | 1.5 M |
+| 200 M  | KD     |  26.2 s |  536.2 s |  444.2 s |  334 MB | 3.1 M |
+| 300 M  | KD     |  45.3 s |  833.7 s |  569.0 s |  444 MB | 4.7 M |
+| 500 M  | Morton |  65.4 s | 1 328.0 s |  744.4 s |  810 MB | 7.8 M |
+| **1 B** | **Morton** | **135.3 s** | **4 390.8 s** | **1 596.3 s** | **1 577 MB** | **15.6 M** |
 
-Resident heap is what the skeleton tree pins after `LoadFromCHStaging` + GC. Raw points live in ClickHouse; Go holds only the bounds-only leaf index. Rollup `OPTIMIZE FINAL` collapses per-insert parts into a single sorted run per zoom partition — needed once after bulk load so the rollup path scans contiguous data.
+Resident heap is what the skeleton tree pins after `Load…` returns + GC. Raw points live in ClickHouse; Go holds only the bounds-only leaf index. Rollup `OPTIMIZE FINAL` collapses per-insert parts into a single sorted run per zoom partition — needed once after bulk load so the rollup path scans contiguous data.
 
 #### Query latency (`GetClustersCH`, 5-iter warm avg)
 
@@ -149,14 +156,20 @@ Resident heap is what the skeleton tree pins after `LoadFromCHStaging` + GC. Raw
 | 100 M  |  **3.6 ms** | **10.2 ms** |  **29.0 ms** |  20 795 |  8.80 MB |
 | 200 M  |  **3.5 ms** | **14.9 ms** |  **69.1 ms** |  34 408 | 15.07 MB |
 | 300 M  |  **3.7 ms** | **16.5 ms** | **136.8 ms** |  44 683 | 20.46 MB |
+| 500 M  |  **3.4 ms** | **10.7 ms** | **270.9 ms** |  59 064 | 28.45 MB |
+| **1 B** |  **3.9 ms** | **13.1 ms** | **602.0 ms** |  68 984 | 43.25 MB |
 
-z2 and z8 (`zoom < ZSplit`, default 11) hit the per-zoom rollup materialized views in ClickHouse: latency is flat across the entire size range because a rollup-row count is bounded by the zoom-tile grid, not the underlying point count.
+z2 and z8 (`zoom < ZSplit`, default 11) hit the per-zoom rollup materialized views in ClickHouse: latency is flat across the entire 200× size range because the rollup-row count is bounded by the zoom-tile grid, not the underlying point count.
 
-z14 (`zoom >= ZSplit`) walks the in-memory skeleton tree, fetches the matching leaf-id ranges from ClickHouse, and runs the Supercluster-style radius clustering on the returned points. Latency scales with the *density of points inside the viewport* — at 300 M CONUS points the 0.5° × 0.5° viewport contains ≈ 50 K points, and the system returns 44 683 clusters in 137 ms (95 % of which is `fetchLeafPoints` + `clusterPoints`).
+z14 (`zoom >= ZSplit`) walks the in-memory skeleton tree, fetches the matching leaf-id ranges from ClickHouse, and runs the Supercluster-style radius clustering on the returned points. Latency scales with the *density of points inside the viewport* — at 1 B CONUS points the 0.5° × 0.5° viewport contains ≈ 170 K points (most of the wall time is `fetchLeafPoints` + `clusterPoints` on the ~120 K points pulled back into Go).
 
-#### Limits encountered
+#### Why streaming unlocked 500 M → 1 B
 
-300 M is the realistic ceiling on this hardware (94 GB RAM) with the current Load path. During `LoadFromCHStaging` Go materializes one `[]chSpatialRow` (12 B/row) and one `[]KDPoint` (16 B/row), and the `INSERT … SELECT … JOIN staging ⨝ id_map` runs server-side. Even with the in-place skeleton sort (introduced for this scale push) and `join_algorithm='full_sorting_merge'` (which bounds CH-server JOIN RAM), 500 M points combined Go heap (~14 GB) + ClickHouse working set + OS page cache for the ~50 GB staging partition exhaust RAM. Pushing past 300 M needs a streaming Load path: project rows on read, drop the spatial slice, keep external IDs as a packed `[]uint32`. That's the next optimization target.
+The KD-sort load path tops out around 300 M on a 94 GB box because it materializes one `[]chSpatialRow` (12 B/row) and one `[]KDPoint` (16 B/row) in Go and then runs an in-place median-partition sort. At 500 M that's ~14 GB of resident Go heap on top of the CH-server working set and OS page cache — the combination thrashes swap and OOMs.
+
+`LoadFromCHStreaming` moves the spatial sort to ClickHouse via `ORDER BY mortonEncode(lng_u32, lat_u32)` (a Z-order space-filling curve) and consumes rows one block at a time. Go accumulates `NodeSize` points per chunk → emits a `SkeletonLeaf` → frees the chunk. Steady-state Go heap = the skeleton tree only (~1.5 GB at 1 B points). The `INSERT … SELECT … JOIN staging ⨝ id_map` is unchanged but the `ORDER BY internal_id` was dropped: MergeTree already sorts blocks by its table `ORDER BY` on insert, so re-sorting 1 B rows in the JOIN output was costing ~70 GB of CH-server RAM with no observable benefit.
+
+Tradeoff: Morton leaves are slightly looser than KD leaves (about 15 % more points returned for the same z14 viewport at the same N), so high-zoom latency is mildly worse than the KD path would be at the same size. For datasets large enough to exhaust the KD path, that's the right trade.
 
 #### Comparison to the pre-ClickHouse baseline (15 M points)
 
@@ -166,9 +179,9 @@ z14 (`zoom >= ZSplit`) walks the in-memory skeleton tree, fetches the matching l
 | 8    | 18.19 s | 12.9 ms |  ~1 400× |
 | 14   | 67.42 s | 6.6 ms | ~10 200× |
 
-Columns are not strictly apples-to-apples — the old benchmarks always queried the full CONUS bbox, unrealistic at z14 where a real viewport is one neighborhood. With zoom-appropriate viewports the new system stays interactive across the entire zoom range, and now scales to 20× the point count of the old in-memory system (300 M vs ~15 M before the heap blew up).
+Columns are not strictly apples-to-apples — the old benchmarks always queried the full CONUS bbox, unrealistic at z14 where a real viewport is one neighborhood. With zoom-appropriate viewports the new system stays interactive across the entire zoom range, and now scales to ~67× the point count of the old in-memory system (1 B vs ~15 M before the heap blew up).
 
-Raw results: `benchmark_results/scale_full_rerun.txt`, `benchmark_results/baseline_15M.txt`.
+Raw results: `benchmark_results/scale_full_rerun.txt`, `benchmark_results/scale_streaming_500M.txt`, `benchmark_results/scale_streaming_1B.txt`, `benchmark_results/baseline_15M.txt`.
 
 ### Limitations
 - Single-node ClickHouse only; no distributed CH support

--- a/README.md
+++ b/README.md
@@ -132,18 +132,24 @@ All sizes are measured against `LoadFromCHStreaming`, which pushes the spatial s
 
 | Points | CH stage gen | Load (skeleton + canonical points) | Rollup OPTIMIZE FINAL | Resident heap after load | Skeleton leaves |
 |--------|-------------:|-----------------------------------:|----------------------:|-------------------------:|----------------:|
-|   5 M  |   1.0 s |    13.5 s |   4.3 s |   10 MB |  78 K |
-|  15 M  |   2.1 s |    38.6 s |   4.7 s |   28 MB | 234 K |
-|  50 M  |   6.4 s |   131.4 s |   5.6 s |   74 MB | 781 K |
-| 100 M  |  12.8 s |   255.7 s |   5.8 s |  174 MB | 1.5 M |
-| 200 M  |  26.4 s |   538.4 s |   8.1 s |  336 MB | 3.1 M |
-| 300 M  |  40.8 s |   799.0 s |   7.6 s |  418 MB | 4.7 M |
-| 500 M  |  69.4 s | 1 320.1 s |   6.2 s |  812 MB | 7.8 M |
-| **1 B** | **178.5 s** | **2 747.3 s** | **7.4 s** | **1 580 MB** | **15.6 M** |
+|   5 M  |   1.8 s |    17.7 s |   5.3 s |   10 MB |  78 K |
+|  15 M  |   5.3 s |    33.9 s |   5.9 s |   26 MB | 234 K |
+|  50 M  |  16.8 s |    90.7 s |   6.1 s |   74 MB | 781 K |
+| 100 M  |  37.4 s |   168.4 s |   6.0 s |  174 MB | 1.5 M |
+| 200 M  |  74.5 s |   315.9 s |   6.3 s |  336 MB | 3.1 M |
+| 300 M  | 106.6 s |   475.4 s |   6.2 s |  418 MB | 4.7 M |
+| 500 M  | 180.1 s |   793.1 s |   6.4 s |  812 MB | 7.8 M |
+| **1 B** | **393.1 s** | **1 732.9 s** | **6.4 s** | **1 580 MB** | **15.6 M** |
 
 Resident heap is what the skeleton tree pins after `Load…` returns + GC. Raw points live in ClickHouse; Go holds only the bounds-only leaf index. Rollup `OPTIMIZE FINAL` collapses per-insert parts into a single sorted run per zoom partition — needed once after bulk load so the rollup path scans contiguous data.
 
 Rollup MVs are only created for zooms `[MinRollupZoom..MaxRollupZoom]` (currently 2–10), because the routing cutoff `ZSplit=11` means zooms 11+ are answered by the in-memory skeleton tree, never by the rollup path. Dropping the z11–z16 MVs cuts both incremental Load wall-clock (fewer MVs to fan to per insert block) and `OPTIMIZE FINAL` from minutes to single-digit seconds at every dataset size measured.
+
+##### Deferred MV populate (`CLUSTOPHER_DEFERRED_ROLLUPS=1`, default on)
+
+Each MV defined `FROM clustopher.points` fires per insert block, so 1 B point insertions used to drive ~9 B partial MV row writes (one per zoom level per source row) plus their downstream SummingMergeTree merges. Loading instead detaches all rollup MVs for the duration of `populatePointsFromStaging`, then runs one pre-aggregated `INSERT … SELECT … GROUP BY tile_x, tile_y` per zoom from the now-populated `points` table. Each batch writes at most 4ᴺ rollup rows (only ~1.5 M total across z2–z10 at 1 B points) so the SummingMergeTree starts in already-merged shape.
+
+Wall-clock effect at 1 B points: Load drops from 46 min (v3, incremental MVs) to **29 min** (deferred); total cold-load wall drops 49 min → **36 min**. The win scales with N — at 5 M the per-insert MV cost was tiny so deferred is slightly slower; at 100 M+ it's a clean 30–40 % cut.
 
 #### Query latency (`GetClustersCH`, 5-iter warm avg)
 
@@ -180,7 +186,9 @@ Tradeoff: Morton leaves are slightly looser than KD leaves (about 15 % more poin
 
 Columns are not strictly apples-to-apples — the old benchmarks always queried the full CONUS bbox, unrealistic at z14 where a real viewport is one neighborhood. With zoom-appropriate viewports the new system stays interactive across the entire zoom range, and now scales to ~67× the point count of the old in-memory system (1 B vs ~15 M before the heap blew up).
 
-Raw results: `benchmark_results/scale_streaming_full_v3.txt`, `benchmark_results/scale_streaming_1B_v3.txt`, `benchmark_results/baseline_15M.txt`.
+Raw results: `benchmark_results/scale_deferred_full.txt`, `benchmark_results/scale_deferred_1B.txt`, `benchmark_results/baseline_15M.txt`.
+
+> **Note on `CH stage gen` column**: jumped vs the prior README (e.g. 12.8 s → 37.4 s at 100 M) because `generateDenseStagingPoints` now emits richer test metadata (4 categorical + 3 numeric fields per point via separate `cityHash64(number, salt)` draws). That's unrelated to deferred-rollup work — it's bench-rig cost, not production cost.
 
 ### Limitations
 - Single-node ClickHouse only; no distributed CH support

--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ Two load paths are exercised:
 | 200 M  | KD     |  26.2 s |  536.2 s |  444.2 s |  334 MB | 3.1 M |
 | 300 M  | KD     |  45.3 s |  833.7 s |  569.0 s |  444 MB | 4.7 M |
 | 500 M  | Morton |  65.4 s | 1 328.0 s |  744.4 s |  810 MB | 7.8 M |
-| **1 B** | **Morton** | **135.3 s** | **4 390.8 s** | **1 596.3 s** | **1 577 MB** | **15.6 M** |
+| **1 B** | **Morton** | **178.5 s** | **2 747.3 s** | **7.4 s** | **1 580 MB** | **15.6 M** |
 
 Resident heap is what the skeleton tree pins after `Load…` returns + GC. Raw points live in ClickHouse; Go holds only the bounds-only leaf index. Rollup `OPTIMIZE FINAL` collapses per-insert parts into a single sorted run per zoom partition — needed once after bulk load so the rollup path scans contiguous data.
+
+Rollup MVs are only created for zooms `[MinRollupZoom..MaxRollupZoom]` (currently 2–10), because the routing cutoff `ZSplit=11` means zooms 11+ are answered by the in-memory skeleton tree, never by the rollup path. Dropping the z11–z16 MVs at 1 B points cuts Load wall-clock 46% (less write-amplification on insert) and `OPTIMIZE FINAL` 99.7% (z11–z16 would have held ~1 B rollup rows because their tile grids approach point count at high zoom).
 
 #### Query latency (`GetClustersCH`, 5-iter warm avg)
 
@@ -157,7 +159,7 @@ Resident heap is what the skeleton tree pins after `Load…` returns + GC. Raw p
 | 200 M  |  **3.5 ms** | **14.9 ms** |  **69.1 ms** |  34 408 | 15.07 MB |
 | 300 M  |  **3.7 ms** | **16.5 ms** | **136.8 ms** |  44 683 | 20.46 MB |
 | 500 M  |  **3.4 ms** | **10.7 ms** | **270.9 ms** |  59 064 | 28.45 MB |
-| **1 B** |  **3.9 ms** | **13.1 ms** | **602.0 ms** |  68 984 | 43.25 MB |
+| **1 B** |  **4.3 ms** | **14.2 ms** | **1 000.3 ms** |  68 986 | 262.08 MB |
 
 z2 and z8 (`zoom < ZSplit`, default 11) hit the per-zoom rollup materialized views in ClickHouse: latency is flat across the entire 200× size range because the rollup-row count is bounded by the zoom-tile grid, not the underlying point count.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The motivation was a pure in-memory predecessor (KD-tree + grid clustering + zst
 - Bounds-only skeleton KD-tree in Go for fast spatial pruning at high zoom levels
 - ClickHouse materialized-view rollups for low-zoom aggregation
 - Dynamic routing between rollup and skeleton paths based on zoom level (`ZSplit`, default 11)
-- Verified at **1 billion** points on a single box (94 GB RAM, single-node CH 24.8) with sub-15 ms low/mid-zoom queries via a Morton-sorted streaming load path
+- Verified at **3 billion** points on a single box (94 GB RAM, single-node CH 24.8) with sub-20 ms low/mid-zoom queries via a CH-side single-pass load path
 
 ### Metrics & Metadata
 - Support for arbitrary numeric metrics on points
@@ -126,7 +126,11 @@ CLICKHOUSE_DSN=clickhouse://default:@localhost:9000/clustopher_test go test ./..
 
 Measured on AMD Ryzen 9 5900X (24 threads), single-node ClickHouse 24.8 in Docker, random points uniformly distributed across the CONUS bounding box. Viewports are zoom-appropriate (continental at low zoom, state at mid zoom, city at high zoom):
 
-All sizes are measured against `LoadFromCHStreaming`, which pushes the spatial sort into ClickHouse via a Morton-encoded `ORDER BY`, streams the sorted rows back in `NodeSize` chunks, and builds skeleton leaves on the fly. Go heap is bounded by the skeleton tree alone (≈ 1.6 GB at 1 B points). An alternative `LoadFromCHStaging` path runs an exact KD-tree median-partition sort in Go — slightly tighter leaf bounds and better high-zoom latency, but heap grows linearly so it tops out around 300 M on this box.
+Three load paths exist, in increasing scale ceiling:
+
+- `LoadFromCHStaging` (KD): exact KD-tree median-partition sort in Go. Tightest leaf bounds, best high-zoom latency, but heap grows linearly → tops out ~300 M on this box.
+- `LoadFromCHStreaming` (Morton-stream): pushes the spatial sort into ClickHouse via a Morton-encoded `ORDER BY`, streams sorted rows back in `NodeSize` chunks, writes an `(external→internal)` id map, then `INSERT … SELECT … JOIN staging ⨝ id_map`. Go heap bounded by the skeleton tree alone (≈ 1.6 GB at 1 B). Verified to 1 B; the 3B×3B populate JOIN exhausts CH-server RAM at 3 B.
+- `LoadFromCHSinglePass` (CH-single, `CLUSTOPHER_SCALE_SINGLEPASS=1`): assigns internal ids entirely in ClickHouse with `rowNumberInAllBlocks()` over the Morton `ORDER BY`, writing the canonical `points` table in one `INSERT … SELECT` — **no id-map table and no JOIN**. Skeleton leaf bounds are read back with a single `GROUP BY intDiv(id-1, NodeSize)` (web-mercator monotonicity makes corner projection exact). This is what unlocked 3 B.
 
 #### Scale (load + storage)
 
@@ -140,6 +144,9 @@ All sizes are measured against `LoadFromCHStreaming`, which pushes the spatial s
 | 300 M  | 106.6 s |   475.4 s |   6.2 s |  418 MB | 4.7 M |
 | 500 M  | 180.1 s |   793.1 s |   6.4 s |  812 MB | 7.8 M |
 | **1 B** | **393.1 s** | **1 732.9 s** | **6.4 s** | **1 580 MB** | **15.6 M** |
+| **3 B** † | **1 333.5 s** | **4 175.1 s** | **6.1 s** | **4 708 MB** | **46.9 M** |
+
+† 3 B uses `LoadFromCHSinglePass` (the Morton-stream JOIN exhausts CH RAM at this size). Load breakdown: 58.0 min INSERT (Morton sort + `rowNumberInAllBlocks` + write), 46 s leaf-bounds read, 9 s skeleton build, 10.7 min deferred rollup batch. The INSERT ran with tight CH caps (1 GB per-thread external-sort threshold, 10 threads, 80 GB hard cap) to keep the wide metrics+metadata payload spilling to disk rather than blowing the 94 GB host — looser caps OOM, this completes.
 
 Resident heap is what the skeleton tree pins after `Load…` returns + GC. Raw points live in ClickHouse; Go holds only the bounds-only leaf index. Rollup `OPTIMIZE FINAL` collapses per-insert parts into a single sorted run per zoom partition — needed once after bulk load so the rollup path scans contiguous data.
 
@@ -163,8 +170,9 @@ Wall-clock effect at 1 B points: Load drops from 46 min (v3, incremental MVs) to
 | 300 M  |  **4.0 ms** | **13.0 ms** |  **269.2 ms** |  47 373 | 115.90 MB |
 | 500 M  |  **5.3 ms** | **13.0 ms** |  **508.8 ms** |  59 064 | 163.22 MB |
 | **1 B** |  **4.3 ms** | **14.2 ms** | **1 000.3 ms** |  68 986 | 262.08 MB |
+| **3 B** |  **3.4 ms** | **17.5 ms** | **3 984.2 ms** |  58 727 | 993.57 MB |
 
-z2 and z8 (`zoom < ZSplit`, default 11) hit the per-zoom rollup materialized views in ClickHouse: latency is flat across the entire 200× size range because the rollup-row count is bounded by the zoom-tile grid, not the underlying point count.
+z2 and z8 (`zoom < ZSplit`, default 11) hit the per-zoom rollup materialized views in ClickHouse: latency is flat across the entire 600× size range because the rollup-row count is bounded by the zoom-tile grid, not the underlying point count.
 
 z14 (`zoom >= ZSplit`) walks the in-memory skeleton tree, fetches the matching leaf-id ranges from ClickHouse, and runs the Supercluster-style radius clustering on the returned points. Latency scales with the *density of points inside the viewport* — at 1 B CONUS points the 0.5° × 0.5° viewport contains ≈ 170 K points (most of the wall time is `fetchLeafPoints` + `clusterPoints` on the ~120 K points pulled back into Go).
 
@@ -176,6 +184,22 @@ The KD-sort load path tops out around 300 M on a 94 GB box because it materializ
 
 Tradeoff: Morton leaves are slightly looser than KD leaves (about 15 % more points returned for the same z14 viewport at the same N), so high-zoom latency is mildly worse than the KD path would be at the same size. For datasets large enough to exhaust the KD path, that's the right trade.
 
+#### Why single-pass unlocked 1 B → 3 B
+
+The Morton-stream path still does an `INSERT … SELECT … staging ⨝ id_map` to attach the Go-assigned internal id back onto the full payload. At 3 B that join's output is ~450 GB of `(x, y, metrics, metadata)` and the merge-join working set + MergeTree part formation push CH-server RAM past the host ceiling.
+
+`LoadFromCHSinglePass` removes the id-map table and the join entirely. Internal ids are assigned inside ClickHouse: `SELECT toUInt32(rowNumberInAllBlocks() + 1) AS id, … FROM staging_points ORDER BY mortonEncode(…)`. `rowNumberInAllBlocks()` is evaluated *after* the global `ORDER BY`, so ids 1..N land in exact Morton order in a single streaming `INSERT` — no second table, no join. The skeleton is then rebuilt from the canonical table with one aggregate scan:
+
+```sql
+SELECT intDiv(id-1, NodeSize) AS leaf,
+       min(x), max(x), min(y), max(y), min(id), max(id), count()
+FROM points WHERE cluster_id = ? GROUP BY leaf ORDER BY leaf
+```
+
+Web-mercator projection is monotonic in each axis within the supported latitude band, so projecting the `(min_lng, max_lat)` and `(max_lng, min_lat)` corners of each leaf yields exact pixel-space bounds — no need to stream all 3 B rows through Go. At 3 B the leaf-bounds read is 46 s and the skeleton rebuild 9 s.
+
+Cost: `rowNumberInAllBlocks()` forces a single-threaded final merge in CH, so the big `INSERT` can't fully parallelize. At 100 M (fits in RAM, no spill) the single-pass load is 131 s vs streaming's 168 s — 22 % faster. At 3 B the tight anti-OOM caps force heavy spill and the INSERT stretches to 58 min, but it *completes* where streaming OOMs. Net: single-pass is both faster at mid-scale and the only path that reaches 3 B on this hardware.
+
 #### Comparison to the pre-ClickHouse baseline (15 M points)
 
 | Zoom | Old (full bbox, in-memory KD-tree) | New (zoom-appropriate viewport, CH-backed) | Speedup |
@@ -184,9 +208,9 @@ Tradeoff: Morton leaves are slightly looser than KD leaves (about 15 % more poin
 | 8    | 18.19 s | 11.1 ms |  ~1 600× |
 | 14   | 67.42 s | 19.8 ms | ~3 400× |
 
-Columns are not strictly apples-to-apples — the old benchmarks always queried the full CONUS bbox, unrealistic at z14 where a real viewport is one neighborhood. With zoom-appropriate viewports the new system stays interactive across the entire zoom range, and now scales to ~67× the point count of the old in-memory system (1 B vs ~15 M before the heap blew up).
+Columns are not strictly apples-to-apples — the old benchmarks always queried the full CONUS bbox, unrealistic at z14 where a real viewport is one neighborhood. With zoom-appropriate viewports the new system stays interactive across the entire zoom range, and now scales to ~200× the point count of the old in-memory system (3 B vs ~15 M before the heap blew up).
 
-Raw results: `benchmark_results/scale_deferred_full.txt`, `benchmark_results/scale_deferred_1B.txt`, `benchmark_results/baseline_15M.txt`.
+Raw results: `benchmark_results/scale_deferred_full.txt`, `benchmark_results/scale_deferred_1B.txt`, `benchmark_results/scale_singlepass_3B.txt`, `benchmark_results/baseline_15M.txt`.
 
 > **Note on `CH stage gen` column**: jumped vs the prior README (e.g. 12.8 s → 37.4 s at 100 M) because `generateDenseStagingPoints` now emits richer test metadata (4 categorical + 3 numeric fields per point via separate `cityHash64(number, salt)` draws). That's unrelated to deferred-rollup work — it's bench-rig cost, not production cost.
 
@@ -195,3 +219,7 @@ Raw results: `benchmark_results/scale_deferred_full.txt`, `benchmark_results/sca
 - No point-level updates: reloading a cluster drops its CH partition and reinserts all points
 - Metric aggregations are sum/avg only (no arbitrary aggregation functions)
 - Skeleton tree is rebuilt from CH on first access after process restart or LRU eviction
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/cluster/benchmark_ch_test.go
+++ b/cluster/benchmark_ch_test.go
@@ -347,8 +347,12 @@ func generateDenseStagingPoints(ctx context.Context, c *CHClient, clusterID stri
 	// NB: previously used `randCanonical()` for x and y in the same SELECT; the
 	// CH planner folded the two calls into a single value, so every generated
 	// point landed on the diagonal `y = MinY + (x-MinX) * (MaxY-MinY)/(MaxX-MinX)`.
-	// Use cityHash64(number, salt) with distinct salts per axis so x, y, and the
-	// metric draw are independent uniform variates.
+	// Use cityHash64(number, salt) with distinct salts per axis so each draw is
+	// an independent uniform variate.
+	//
+	// Metrics: price ($0–$500), rating (1.0–5.0), visitors (0–10k).
+	// Metadata: category (5 buckets), borough (5 buckets), verified (yes/no
+	// ~70/30), tier (gold/silver/bronze ~10/30/60).
 	return c.Conn().Exec(ctx, `
         INSERT INTO clustopher.staging_points (cluster_id, external_id, x, y, metrics, metadata)
         SELECT
@@ -356,8 +360,21 @@ func generateDenseStagingPoints(ctx context.Context, c *CHClient, clusterID stri
             toUInt32(number + 1) AS external_id,
             toFloat32(? + (cityHash64(number, 1) / 18446744073709551615.0) * (? - ?)) AS x,
             toFloat32(? + (cityHash64(number, 2) / 18446744073709551615.0) * (? - ?)) AS y,
-            map('value', toFloat32((cityHash64(number, 3) / 18446744073709551615.0) * 100)) AS metrics,
-            map('type', 'test') AS metadata
+            map(
+                'price',    toFloat32((cityHash64(number, 3) / 18446744073709551615.0) * 500.0),
+                'rating',   toFloat32(1.0 + (cityHash64(number, 7) / 18446744073709551615.0) * 4.0),
+                'visitors', toFloat32(floor((cityHash64(number, 8) / 18446744073709551615.0) * 10000))
+            ) AS metrics,
+            map(
+                'category', ['retail','grocery','restaurant','gas','pharmacy'][1 + toInt32(cityHash64(number, 4) % 5)],
+                'borough',  ['manhattan','brooklyn','queens','bronx','staten'][1 + toInt32(cityHash64(number, 5) % 5)],
+                'verified', if(cityHash64(number, 6) % 100 < 70, 'yes', 'no'),
+                'tier',     multiIf(
+                                cityHash64(number, 9) % 100 < 10, 'gold',
+                                cityHash64(number, 9) % 100 < 40, 'silver',
+                                'bronze'
+                            )
+            ) AS metadata
         FROM numbers(?)
     `, clusterID, bounds.MinX, bounds.MaxX, bounds.MinX, bounds.MinY, bounds.MaxY, bounds.MinY, uint64(n))
 }

--- a/cluster/benchmark_scale_test.go
+++ b/cluster/benchmark_scale_test.go
@@ -124,15 +124,26 @@ func TestScalePerf(t *testing.T) {
 		sc.SetClusterID(clusterID)
 
 		loadStart := time.Now()
-		if err := sc.LoadFromCHStaging(ctx); err != nil {
-			res.err = fmt.Sprintf("load: %v", err)
+		streaming := os.Getenv("CLUSTOPHER_SCALE_STREAMING") == "1"
+		var loadErr error
+		if streaming {
+			loadErr = sc.LoadFromCHStreaming(ctx)
+		} else {
+			loadErr = sc.LoadFromCHStaging(ctx)
+		}
+		if loadErr != nil {
+			res.err = fmt.Sprintf("load: %v", loadErr)
 			results = append(results, res)
 			cleanup()
 			t.Logf("FAIL %s: %s", humanCount(n), res.err)
 			continue
 		}
 		res.loadSec = time.Since(loadStart).Seconds()
-		t.Logf("loaded %s points (CH-first) in %.1fs", humanCount(n), res.loadSec)
+		loadPath := "KD"
+		if streaming {
+			loadPath = "Morton-stream"
+		}
+		t.Logf("loaded %s points (%s) in %.1fs", humanCount(n), loadPath, res.loadSec)
 
 		// Free intermediates and force GC so the resident-after-load measurement
 		// reflects what the skeleton actually pins.

--- a/cluster/benchmark_scale_test.go
+++ b/cluster/benchmark_scale_test.go
@@ -125,10 +125,14 @@ func TestScalePerf(t *testing.T) {
 
 		loadStart := time.Now()
 		streaming := os.Getenv("CLUSTOPHER_SCALE_STREAMING") == "1"
+		singlepass := os.Getenv("CLUSTOPHER_SCALE_SINGLEPASS") == "1"
 		var loadErr error
-		if streaming {
+		switch {
+		case singlepass:
+			loadErr = sc.LoadFromCHSinglePass(ctx)
+		case streaming:
 			loadErr = sc.LoadFromCHStreaming(ctx)
-		} else {
+		default:
 			loadErr = sc.LoadFromCHStaging(ctx)
 		}
 		if loadErr != nil {
@@ -140,7 +144,10 @@ func TestScalePerf(t *testing.T) {
 		}
 		res.loadSec = time.Since(loadStart).Seconds()
 		loadPath := "KD"
-		if streaming {
+		switch {
+		case singlepass:
+			loadPath = "CH-single"
+		case streaming:
 			loadPath = "Morton-stream"
 		}
 		t.Logf("loaded %s points (%s) in %.1fs", humanCount(n), loadPath, res.loadSec)

--- a/cluster/benchmark_scale_test.go
+++ b/cluster/benchmark_scale_test.go
@@ -97,7 +97,7 @@ func TestScalePerf(t *testing.T) {
 		cleanup := func() {
 			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
 			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
-			for z := 2; z <= 16; z++ {
+			for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
 				_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
 			}
 		}
@@ -161,7 +161,7 @@ func TestScalePerf(t *testing.T) {
 		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
 
 		optStart := time.Now()
-		for z := 2; z <= 16; z++ {
+		for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
 			_ = c.Conn().Exec(ctx, "OPTIMIZE TABLE clustopher.rollup_z"+strconv.Itoa(z)+" PARTITION ? FINAL", clusterID)
 		}
 		res.optimizeSec = time.Since(optStart).Seconds()

--- a/cluster/ch_load.go
+++ b/cluster/ch_load.go
@@ -269,6 +269,12 @@ func (sc *Supercluster) populatePointsFromStaging(ctx context.Context, loadID ui
 	settings["max_bytes_before_external_group_by"] = uint64(8 * 1024 * 1024 * 1024)
 
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(settings))
+	// No ORDER BY internal_id in the SELECT: MergeTree sorts blocks by the
+	// table's ORDER BY (cluster_id, id) on insert anyway. Forcing a full
+	// re-sort of the join output costs an extra N-row sort buffer on the CH
+	// server (~70 GB peak at 500M, blows past system RAM at 1B+). Without it
+	// CH inserts in join-stream order and merges into the final sorted parts
+	// in the background.
 	if err := sc.ch.Conn().Exec(ctx, `
         INSERT INTO clustopher.points (cluster_id, id, external_id, x, y, metrics, metadata)
         SELECT
@@ -284,7 +290,6 @@ func (sc *Supercluster) populatePointsFromStaging(ctx context.Context, loadID ui
             ON s.external_id = m.external_id
         WHERE s.cluster_id = ?
           AND m.load_id = ?
-        ORDER BY m.internal_id
     `, sc.clusterID, loadID); err != nil {
 		return fmt.Errorf("populate points from staging: %w", err)
 	}

--- a/cluster/ch_load.go
+++ b/cluster/ch_load.go
@@ -280,8 +280,12 @@ func (sc *Supercluster) populatePointsFromStaging(ctx context.Context, loadID ui
 		settings[k] = v
 	}
 	settings["join_algorithm"] = "full_sorting_merge"
-	settings["max_bytes_before_external_sort"] = uint64(8 * 1024 * 1024 * 1024)
-	settings["max_bytes_before_external_group_by"] = uint64(8 * 1024 * 1024 * 1024)
+	// Per-thread thresholds: bound aggregate RAM by hard query cap + thread
+	// count. See LoadFromCHStreaming for rationale.
+	settings["max_memory_usage"] = uint64(60 * 1024 * 1024 * 1024)
+	settings["max_threads"] = uint64(20)
+	settings["max_bytes_before_external_sort"] = uint64(4 * 1024 * 1024 * 1024)
+	settings["max_bytes_before_external_group_by"] = uint64(4 * 1024 * 1024 * 1024)
 
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(settings))
 	// No ORDER BY internal_id in the SELECT: MergeTree sorts blocks by the

--- a/cluster/ch_load.go
+++ b/cluster/ch_load.go
@@ -63,8 +63,23 @@ func (sc *Supercluster) LoadFromCHStaging(ctx context.Context) error {
 	if err := sc.writePointIDMap(ctx, loadID, sorted, remap, spatial); err != nil {
 		return err
 	}
+
+	deferred := rollupPopulateDeferred()
+	if deferred {
+		if err := sc.detachRollupMVs(ctx); err != nil {
+			return err
+		}
+		defer func() {
+			_ = sc.attachRollupMVs(context.Background())
+		}()
+	}
 	if err := sc.populatePointsFromStaging(ctx, loadID); err != nil {
 		return err
+	}
+	if deferred {
+		if err := sc.populateRollupsBatch(ctx); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cluster/ch_load.go
+++ b/cluster/ch_load.go
@@ -151,7 +151,7 @@ func (sc *Supercluster) resetCanonicalCluster(ctx context.Context) error {
 	if err := sc.ch.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", sc.clusterID); err != nil {
 		return fmt.Errorf("drop points partition: %w", err)
 	}
-	for z := 2; z <= 16; z++ {
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
 		if err := sc.ch.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", sc.clusterID); err != nil {
 			return fmt.Errorf("drop rollup_z%d partition: %w", z, err)
 		}

--- a/cluster/ch_load_rollup.go
+++ b/cluster/ch_load_rollup.go
@@ -56,41 +56,116 @@ func (sc *Supercluster) attachRollupMVs(ctx context.Context) error {
 	return firstErr
 }
 
-// populateRollupsBatch runs one pre-aggregated GROUP BY INSERT per rollup
-// zoom, populating clustopher.rollup_z{N} for the current cluster from the
-// already-populated clustopher.points partition. Mirrors the per-row math
-// the MV would have done, but pre-aggregates so the SummingMergeTree gets
-// one row per (cluster_id, tile_x, tile_y) instead of one per source point.
+// rollupCascadeEnabled reports whether batch rollup populate should derive
+// each zoom from the zoom above it instead of rescanning the full points
+// partition per zoom. Enabled by default (CLUSTOPHER_ROLLUP_CASCADE != "0").
+func rollupCascadeEnabled() bool {
+	return os.Getenv("CLUSTOPHER_ROLLUP_CASCADE") != "0"
+}
+
+// populateRollupsBatch populates clustopher.rollup_z{N} for the current
+// cluster from the already-populated clustopher.points partition, for all
+// zooms in [MinRollupZoom, MaxRollupZoom]. Mirrors the per-row math the MV
+// would have done, but pre-aggregates so the SummingMergeTree gets one row
+// per (cluster_id, tile_x, tile_y) instead of one per source point.
 //
 // At 1B points this writes a total of ~1.5M rollup rows across all 9 zooms
 // (tile counts cap at 4^z which is much smaller than the point count for the
 // MaxRollupZoom we keep). The MV path would have written ~9B partial rows
 // then merged them. Same end state, vastly less write amplification.
 func (sc *Supercluster) populateRollupsBatch(ctx context.Context) error {
-	radius := DefaultRollupRadius
+	if rollupCascadeEnabled() {
+		return sc.populateRollupsCascade(ctx)
+	}
+	return sc.populateRollupsDirect(ctx)
+}
 
+// rollupFromPointsSQL builds the INSERT that aggregates the points partition
+// directly into rollup_z{z}. Shared by the direct (every zoom) and cascade
+// (top zoom only) populate strategies.
+func rollupFromPointsSQL(z int) string {
+	radius := DefaultRollupRadius
+	return fmt.Sprintf(`
+        INSERT INTO clustopher.rollup_z%d (cluster_id, tile_x, tile_y, cnt, sum_x, sum_y, metric_sums, metric_cnts)
+        SELECT
+            cluster_id,
+            toUInt32(((x + 180) / 360) * pow(2, %d) * 512 / %d) AS tile_x,
+            toUInt32(((1 - log(tan(y * pi()/180) + 1/cos(y * pi()/180)) / pi()) / 2) * pow(2, %d) * 512 / %d) AS tile_y,
+            count() AS cnt,
+            sum(x) AS sum_x,
+            sum(y) AS sum_y,
+            sumMap(mapApply((k, v) -> (k, toFloat64(v)), metrics)) AS metric_sums,
+            sumMap(mapApply((k, v) -> (k, toUInt64(1)),  metrics)) AS metric_cnts
+        FROM clustopher.points
+        WHERE cluster_id = ?
+        GROUP BY cluster_id, tile_x, tile_y
+    `, z, z, radius, z, radius)
+}
+
+// populateRollupsDirect rescans the full points partition once per zoom.
+// Kept as the CLUSTOPHER_ROLLUP_CASCADE=0 fallback and as the reference
+// implementation the cascade is equivalence-tested against.
+func (sc *Supercluster) populateRollupsDirect(ctx context.Context) error {
 	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+		insertCtx := chQueryCtx(ctx, "rollup-z"+strconv.Itoa(z), insertSettings)
+		zt := time.Now()
+		if err := sc.ch.Conn().Exec(insertCtx, rollupFromPointsSQL(z), sc.clusterID); err != nil {
+			return fmt.Errorf("batch populate rollup_z%d: %w", z, err)
+		}
+		log.Printf("[rollup] z%d populate in %s", z, time.Since(zt).Round(time.Millisecond))
+	}
+	return nil
+}
+
+// populateRollupsCascade scans the points partition once (for MaxRollupZoom),
+// then derives each lower zoom from the zoom above it. Exact because
+// tile coords at z-1 are intDiv(tile coords at z, 2):
+//
+//	tile(z) = floor(w * 2^z * 512/radius) and the float expression for z-1
+//	is exactly half the one for z (scaling by a power of two is exact in
+//	IEEE-754), so floor(floor(2v)/2) == floor(v) applies.
+//
+// All rollup columns are additive (cnt, sum_x, sum_y, sumMap maps), so
+// re-aggregating z's tiles under z-1's coords yields the same result as
+// aggregating the source points — up to float summation order, which is
+// already unspecified in the direct path (parallel aggregation).
+//
+// The GROUP BY also makes reading the SummingMergeTree source safe while its
+// parts are unmerged: partial rows for the same tile sum into one output row.
+//
+// At 3B points this replaces 9 full scans (~71 s each) with one full scan
+// plus 8 scans of <3M rollup rows.
+func (sc *Supercluster) populateRollupsCascade(ctx context.Context) error {
+	top := MaxRollupZoom
+	insertCtx := chQueryCtx(ctx, "rollup-z"+strconv.Itoa(top), insertSettings)
+	zt := time.Now()
+	if err := sc.ch.Conn().Exec(insertCtx, rollupFromPointsSQL(top), sc.clusterID); err != nil {
+		return fmt.Errorf("cascade populate rollup_z%d: %w", top, err)
+	}
+	log.Printf("[rollup] z%d populate (from points) in %s", top, time.Since(zt).Round(time.Millisecond))
+
+	for z := top - 1; z >= MinRollupZoom; z-- {
 		insertCtx := chQueryCtx(ctx, "rollup-z"+strconv.Itoa(z), insertSettings)
 		zt := time.Now()
 		q := fmt.Sprintf(`
             INSERT INTO clustopher.rollup_z%d (cluster_id, tile_x, tile_y, cnt, sum_x, sum_y, metric_sums, metric_cnts)
             SELECT
                 cluster_id,
-                toUInt32(((x + 180) / 360) * pow(2, %d) * 512 / %d) AS tile_x,
-                toUInt32(((1 - log(tan(y * pi()/180) + 1/cos(y * pi()/180)) / pi()) / 2) * pow(2, %d) * 512 / %d) AS tile_y,
-                count() AS cnt,
-                sum(x) AS sum_x,
-                sum(y) AS sum_y,
-                sumMap(mapApply((k, v) -> (k, toFloat64(v)), metrics)) AS metric_sums,
-                sumMap(mapApply((k, v) -> (k, toUInt64(1)),  metrics)) AS metric_cnts
-            FROM clustopher.points
+                intDiv(tile_x, 2) AS tx,
+                intDiv(tile_y, 2) AS ty,
+                sum(cnt) AS cnt,
+                sum(sum_x) AS sum_x,
+                sum(sum_y) AS sum_y,
+                sumMap(metric_sums) AS metric_sums,
+                sumMap(metric_cnts) AS metric_cnts
+            FROM clustopher.rollup_z%d
             WHERE cluster_id = ?
-            GROUP BY cluster_id, tile_x, tile_y
-        `, z, z, radius, z, radius)
+            GROUP BY cluster_id, tx, ty
+        `, z, z+1)
 		if err := sc.ch.Conn().Exec(insertCtx, q, sc.clusterID); err != nil {
-			return fmt.Errorf("batch populate rollup_z%d: %w", z, err)
+			return fmt.Errorf("cascade populate rollup_z%d: %w", z, err)
 		}
-		log.Printf("[rollup] z%d populate in %s", z, time.Since(zt).Round(time.Millisecond))
+		log.Printf("[rollup] z%d populate (from z%d) in %s", z, z+1, time.Since(zt).Round(time.Millisecond))
 	}
 	return nil
 }

--- a/cluster/ch_load_rollup.go
+++ b/cluster/ch_load_rollup.go
@@ -3,10 +3,10 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
-
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"time"
 )
 
 // rollupPopulateMode reports whether rollups should be deferred and batch-
@@ -68,13 +68,10 @@ func (sc *Supercluster) attachRollupMVs(ctx context.Context) error {
 // then merged them. Same end state, vastly less write amplification.
 func (sc *Supercluster) populateRollupsBatch(ctx context.Context) error {
 	radius := DefaultRollupRadius
-	settings := clickhouse.Settings{}
-	for k, v := range insertSettings {
-		settings[k] = v
-	}
-	insertCtx := clickhouse.Context(ctx, clickhouse.WithSettings(settings))
 
 	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+		insertCtx := chQueryCtx(ctx, "rollup-z"+strconv.Itoa(z), insertSettings)
+		zt := time.Now()
 		q := fmt.Sprintf(`
             INSERT INTO clustopher.rollup_z%d (cluster_id, tile_x, tile_y, cnt, sum_x, sum_y, metric_sums, metric_cnts)
             SELECT
@@ -93,6 +90,7 @@ func (sc *Supercluster) populateRollupsBatch(ctx context.Context) error {
 		if err := sc.ch.Conn().Exec(insertCtx, q, sc.clusterID); err != nil {
 			return fmt.Errorf("batch populate rollup_z%d: %w", z, err)
 		}
+		log.Printf("[rollup] z%d populate in %s", z, time.Since(zt).Round(time.Millisecond))
 	}
 	return nil
 }

--- a/cluster/ch_load_rollup.go
+++ b/cluster/ch_load_rollup.go
@@ -1,0 +1,98 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// rollupPopulateMode reports whether rollups should be deferred and batch-
+// populated after the canonical points table is fully loaded, instead of
+// being maintained incrementally by the rollup materialized views during the
+// bulk insert. Enabled by default (CLUSTOPHER_DEFERRED_ROLLUPS != "0").
+//
+// Deferred populate skips per-insert MV fan-out (currently 9 MVs at
+// MaxRollupZoom=10) during the staging->points populate, which is by far the
+// largest cost of a bulk load at >100M points, and replaces it with one
+// pre-aggregated GROUP BY INSERT per zoom run after the points table is
+// finalized. That writes <2M rollup rows total at 1B points instead of
+// ~9B partial MV write events.
+func rollupPopulateDeferred() bool {
+	return os.Getenv("CLUSTOPHER_DEFERRED_ROLLUPS") != "0"
+}
+
+// detachRollupMVs removes the materialized-view triggers on clustopher.points
+// for the lifetime of a bulk load so inserts don't fan out to all
+// MaxRollupZoom-MinRollupZoom+1 rollup tables. The underlying rollup_z* data
+// tables are unaffected. Call attachRollupMVs after the bulk insert to
+// restore incremental maintenance for future inserts.
+//
+// Note: DETACH is global — concurrent inserts from other clusters during this
+// window will also bypass MV maintenance. Loads are serialized in the runner,
+// so this is acceptable for our workload.
+func (sc *Supercluster) detachRollupMVs(ctx context.Context) error {
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+		stmt := "DETACH TABLE clustopher.mv_rollup_z" + strconv.Itoa(z)
+		if err := sc.ch.Conn().Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("detach mv_rollup_z%d: %w", z, err)
+		}
+	}
+	return nil
+}
+
+// attachRollupMVs restores the MV triggers detached by detachRollupMVs. Safe
+// to call multiple times; ATTACH on an already-attached table is a no-op.
+func (sc *Supercluster) attachRollupMVs(ctx context.Context) error {
+	var firstErr error
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+		stmt := "ATTACH TABLE clustopher.mv_rollup_z" + strconv.Itoa(z)
+		if err := sc.ch.Conn().Exec(ctx, stmt); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("attach mv_rollup_z%d: %w", z, err)
+		}
+	}
+	return firstErr
+}
+
+// populateRollupsBatch runs one pre-aggregated GROUP BY INSERT per rollup
+// zoom, populating clustopher.rollup_z{N} for the current cluster from the
+// already-populated clustopher.points partition. Mirrors the per-row math
+// the MV would have done, but pre-aggregates so the SummingMergeTree gets
+// one row per (cluster_id, tile_x, tile_y) instead of one per source point.
+//
+// At 1B points this writes a total of ~1.5M rollup rows across all 9 zooms
+// (tile counts cap at 4^z which is much smaller than the point count for the
+// MaxRollupZoom we keep). The MV path would have written ~9B partial rows
+// then merged them. Same end state, vastly less write amplification.
+func (sc *Supercluster) populateRollupsBatch(ctx context.Context) error {
+	radius := DefaultRollupRadius
+	settings := clickhouse.Settings{}
+	for k, v := range insertSettings {
+		settings[k] = v
+	}
+	insertCtx := clickhouse.Context(ctx, clickhouse.WithSettings(settings))
+
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+		q := fmt.Sprintf(`
+            INSERT INTO clustopher.rollup_z%d (cluster_id, tile_x, tile_y, cnt, sum_x, sum_y, metric_sums, metric_cnts)
+            SELECT
+                cluster_id,
+                toUInt32(((x + 180) / 360) * pow(2, %d) * 512 / %d) AS tile_x,
+                toUInt32(((1 - log(tan(y * pi()/180) + 1/cos(y * pi()/180)) / pi()) / 2) * pow(2, %d) * 512 / %d) AS tile_y,
+                count() AS cnt,
+                sum(x) AS sum_x,
+                sum(y) AS sum_y,
+                sumMap(mapApply((k, v) -> (k, toFloat64(v)), metrics)) AS metric_sums,
+                sumMap(mapApply((k, v) -> (k, toUInt64(1)),  metrics)) AS metric_cnts
+            FROM clustopher.points
+            WHERE cluster_id = ?
+            GROUP BY cluster_id, tile_x, tile_y
+        `, z, z, radius, z, radius)
+		if err := sc.ch.Conn().Exec(insertCtx, q, sc.clusterID); err != nil {
+			return fmt.Errorf("batch populate rollup_z%d: %w", z, err)
+		}
+	}
+	return nil
+}

--- a/cluster/ch_load_rollup_test.go
+++ b/cluster/ch_load_rollup_test.go
@@ -1,0 +1,143 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+)
+
+// TestRollupCascadeEquivalence verifies that the cascade rollup populate
+// (z10 from points, z9..z2 each derived from the zoom above) produces the
+// same per-tile aggregates as the direct populate (every zoom from points).
+//
+// Integer columns (cnt, metric_cnts, tile coords) must match exactly; float
+// sums are compared with a relative tolerance because the two strategies sum
+// in different orders.
+func TestRollupCascadeEquivalence(t *testing.T) {
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+
+	const n = 200_000
+	genBBox := KDBounds{MinX: -124, MinY: 26, MaxX: -66, MaxY: 48}
+	specs := map[string]metricSpec{
+		"value_const_1": {CHExpr: "toFloat32(1)"},
+		"value_seq_mod": {CHExpr: "toFloat32((number % 100) + 1)"},
+	}
+
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	clusterID := "ROLLUP_CASCADE_EQ"
+	snapTable := func(z int) string { return "clustopher.tmp_cascade_snap_z" + strconv.Itoa(z) }
+	cleanup := func() {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+		for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+			_ = c.Conn().Exec(ctx, "DROP TABLE IF EXISTS "+snapTable(z))
+		}
+	}
+	cleanup()
+	defer cleanup()
+
+	if err := generateMetricPoints(ctx, c, clusterID, n, genBBox, specs); err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+
+	sc := NewSupercluster(SuperclusterOptions{
+		MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40, Extent: 512, NodeSize: 64,
+	})
+	sc.SetCHClient(c)
+	sc.SetClusterID(clusterID)
+	t.Setenv("CLUSTOPHER_DEFERRED_ROLLUPS", "0") // load without any rollup populate
+	if err := sc.detachRollupMVs(ctx); err != nil {
+		t.Fatalf("detach MVs: %v", err)
+	}
+	defer func() { _ = sc.attachRollupMVs(context.Background()) }()
+	if err := sc.LoadFromCHSinglePass(ctx); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Reference: direct populate, snapshot fully-aggregated tiles per zoom.
+	if err := sc.populateRollupsDirect(ctx); err != nil {
+		t.Fatalf("direct populate: %v", err)
+	}
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+		q := fmt.Sprintf(`
+            CREATE TABLE %s ENGINE = Memory AS
+            SELECT tile_x, tile_y, sum(cnt) AS cnt, sum(sum_x) AS sum_x, sum(sum_y) AS sum_y,
+                   sumMap(metric_sums) AS metric_sums, sumMap(metric_cnts) AS metric_cnts
+            FROM clustopher.rollup_z%d
+            WHERE cluster_id = ?
+            GROUP BY tile_x, tile_y
+        `, snapTable(z), z)
+		if err := c.Conn().Exec(ctx, q, clusterID); err != nil {
+			t.Fatalf("snapshot z%d: %v", z, err)
+		}
+	}
+
+	// Candidate: cascade populate into freshly dropped partitions.
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+		if err := c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID); err != nil {
+			t.Fatalf("drop rollup_z%d: %v", z, err)
+		}
+	}
+	if err := sc.populateRollupsCascade(ctx); err != nil {
+		t.Fatalf("cascade populate: %v", err)
+	}
+
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+		var snapRows, cascadeRows, mismatches uint64
+		if err := c.Conn().QueryRow(ctx,
+			"SELECT count() FROM "+snapTable(z)).Scan(&snapRows); err != nil {
+			t.Fatalf("count snapshot z%d: %v", z, err)
+		}
+		if err := c.Conn().QueryRow(ctx, fmt.Sprintf(
+			"SELECT uniqExact(tile_x, tile_y) FROM clustopher.rollup_z%d WHERE cluster_id = ?", z),
+			clusterID).Scan(&cascadeRows); err != nil {
+			t.Fatalf("count cascade z%d: %v", z, err)
+		}
+		if snapRows == 0 {
+			t.Fatalf("z%d: snapshot empty — reference populate produced no tiles", z)
+		}
+		if snapRows != cascadeRows {
+			t.Errorf("z%d: tile count mismatch direct=%d cascade=%d", z, snapRows, cascadeRows)
+		}
+
+		q := fmt.Sprintf(`
+            SELECT count() FROM (
+                SELECT * FROM %s AS s
+                FULL OUTER JOIN (
+                    SELECT tile_x, tile_y, sum(cnt) AS ccnt, sum(sum_x) AS csum_x, sum(sum_y) AS csum_y,
+                           sumMap(metric_sums) AS cmetric_sums, sumMap(metric_cnts) AS cmetric_cnts
+                    FROM clustopher.rollup_z%d
+                    WHERE cluster_id = ?
+                    GROUP BY tile_x, tile_y
+                ) AS c USING (tile_x, tile_y)
+                WHERE s.cnt != c.ccnt
+                   OR abs(s.sum_x - c.csum_x) > greatest(abs(s.sum_x) * 1e-9, 1e-6)
+                   OR abs(s.sum_y - c.csum_y) > greatest(abs(s.sum_y) * 1e-9, 1e-6)
+                   OR s.metric_cnts != c.cmetric_cnts
+                   OR arraySort(mapKeys(s.metric_sums)) != arraySort(mapKeys(c.cmetric_sums))
+                   OR arrayExists(k -> abs(s.metric_sums[k] - c.cmetric_sums[k]) > greatest(abs(s.metric_sums[k]) * 1e-9, 1e-6), mapKeys(s.metric_sums))
+            )
+        `, snapTable(z), z)
+		if err := c.Conn().QueryRow(ctx, q, clusterID).Scan(&mismatches); err != nil {
+			t.Fatalf("compare z%d: %v", z, err)
+		}
+		if mismatches != 0 {
+			t.Errorf("z%d: %d mismatched tiles between direct and cascade populate", z, mismatches)
+		}
+	}
+}

--- a/cluster/ch_load_singlepass.go
+++ b/cluster/ch_load_singlepass.go
@@ -61,7 +61,7 @@ func (sc *Supercluster) LoadFromCHSinglePass(ctx context.Context) error {
 	insertSettingsBuilt["max_bytes_before_external_sort"] = uint64(1 * 1024 * 1024 * 1024)
 	insertSettingsBuilt["max_bytes_before_external_group_by"] = uint64(1 * 1024 * 1024 * 1024)
 
-	insertCtx := clickhouse.Context(ctx, clickhouse.WithSettings(insertSettingsBuilt))
+	insertCtx := chQueryCtx(ctx, "sp-insert", insertSettingsBuilt)
 	t := time.Now()
 	log.Printf("[ch-single] morton+rowNumber INSERT begin")
 	if err := sc.ch.Conn().Exec(insertCtx, `
@@ -116,11 +116,11 @@ func (sc *Supercluster) readLeafBoundsFromPoints(ctx context.Context) ([]Skeleto
 	}
 	maxZoom := sc.Options.MaxZoom
 
-	queryCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+	queryCtx := chQueryCtx(ctx, "sp-leafbounds", clickhouse.Settings{
 		"max_memory_usage":                   uint64(20 * 1024 * 1024 * 1024),
 		"max_threads":                        uint64(20),
 		"max_bytes_before_external_group_by": uint64(4 * 1024 * 1024 * 1024),
-	}))
+	})
 	rows, err := sc.ch.Conn().Query(queryCtx, `
         SELECT
             intDiv(id - 1, ?) AS leaf,

--- a/cluster/ch_load_singlepass.go
+++ b/cluster/ch_load_singlepass.go
@@ -1,0 +1,174 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// LoadFromCHSinglePass writes the canonical points table directly from staging
+// using CH-side morton sort + rowNumberInAllBlocks() to assign internal IDs,
+// then reads leaf bounds back via GROUP BY for skeleton construction.
+//
+// Compared with LoadFromCHStreaming this:
+//   - Skips the point_id_map_load table + JOIN entirely.
+//   - Skips streaming all 3B rows through Go and the parallel id-map writers.
+//   - Replaces with one big INSERT...SELECT + a small GROUP BY scan.
+//
+// Tradeoff: rowNumberInAllBlocks() forces single-threaded final merge in CH,
+// so the INSERT is bottlenecked on sort+write throughput. Leaf bounds rely on
+// web-mercator monotonicity: projecting the (min_lng, max_lat) and
+// (max_lng, min_lat) corners yields exact pixel-space bounds because the
+// projection is monotonic in each axis within the supported latitude range.
+func (sc *Supercluster) LoadFromCHSinglePass(ctx context.Context) error {
+	if sc.ch == nil {
+		return fmt.Errorf("LoadFromCHSinglePass requires CH client")
+	}
+	if sc.clusterID == "" {
+		return fmt.Errorf("LoadFromCHSinglePass requires clusterID")
+	}
+
+	if err := sc.resetCanonicalCluster(ctx); err != nil {
+		return err
+	}
+
+	deferred := rollupPopulateDeferred()
+	if deferred {
+		t := time.Now()
+		if err := sc.detachRollupMVs(ctx); err != nil {
+			return err
+		}
+		log.Printf("[ch-single] detached rollup MVs in %s", time.Since(t).Round(time.Second))
+		defer func() {
+			_ = sc.attachRollupMVs(context.Background())
+		}()
+	}
+
+	insertSettingsBuilt := clickhouse.Settings{}
+	for k, v := range insertSettings {
+		insertSettingsBuilt[k] = v
+	}
+	// At 3B with metrics+metadata Map columns materialized through the sort
+	// pipeline, total carry exceeds 200 GB if held in RAM. Need aggressive
+	// spilling: lower per-thread sort threshold to 1 GB so spill activates
+	// early, drop max_threads to 10 to bound per-thread read/decode buffers,
+	// raise max_memory_usage to 80 GB hard cap (host has 94 GB).
+	insertSettingsBuilt["max_memory_usage"] = uint64(80 * 1024 * 1024 * 1024)
+	insertSettingsBuilt["max_threads"] = uint64(10)
+	insertSettingsBuilt["max_bytes_before_external_sort"] = uint64(1 * 1024 * 1024 * 1024)
+	insertSettingsBuilt["max_bytes_before_external_group_by"] = uint64(1 * 1024 * 1024 * 1024)
+
+	insertCtx := clickhouse.Context(ctx, clickhouse.WithSettings(insertSettingsBuilt))
+	t := time.Now()
+	log.Printf("[ch-single] morton+rowNumber INSERT begin")
+	if err := sc.ch.Conn().Exec(insertCtx, `
+        INSERT INTO clustopher.points (cluster_id, id, external_id, x, y, metrics, metadata)
+        SELECT
+            cluster_id,
+            toUInt32(rowNumberInAllBlocks() + 1) AS id,
+            external_id,
+            x,
+            y,
+            metrics,
+            metadata
+        FROM clustopher.staging_points
+        WHERE cluster_id = ?
+        ORDER BY mortonEncode(
+            toUInt32((x + 180.0) / 360.0 * 4294967295),
+            toUInt32((y + 90.0)  / 180.0 * 4294967295)
+        )
+    `, sc.clusterID); err != nil {
+		return fmt.Errorf("single-pass insert: %w", err)
+	}
+	log.Printf("[ch-single] INSERT done in %s", time.Since(t).Round(time.Second))
+
+	t = time.Now()
+	leaves, err := sc.readLeafBoundsFromPoints(ctx)
+	if err != nil {
+		return err
+	}
+	log.Printf("[ch-single] read %d leaf bounds in %s", len(leaves), time.Since(t).Round(time.Second))
+
+	t = time.Now()
+	sc.Skeleton = BuildSkeletonFromLeaves(leaves)
+	log.Printf("[ch-single] skeleton built in %s", time.Since(t).Round(time.Second))
+
+	if deferred {
+		t = time.Now()
+		if err := sc.populateRollupsBatch(ctx); err != nil {
+			return err
+		}
+		log.Printf("[ch-single] rollup batch populate in %s", time.Since(t).Round(time.Second))
+	}
+	return nil
+}
+
+// readLeafBoundsFromPoints groups the newly inserted points into NodeSize-row
+// chunks (by id), aggregates min/max lng+lat and id range per chunk, and
+// projects to pixel-space SkeletonLeaf entries.
+func (sc *Supercluster) readLeafBoundsFromPoints(ctx context.Context) ([]SkeletonLeaf, error) {
+	nodeSize := sc.Options.NodeSize
+	if nodeSize < 1 {
+		nodeSize = 1
+	}
+	maxZoom := sc.Options.MaxZoom
+
+	queryCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"max_memory_usage":                   uint64(20 * 1024 * 1024 * 1024),
+		"max_threads":                        uint64(20),
+		"max_bytes_before_external_group_by": uint64(4 * 1024 * 1024 * 1024),
+	}))
+	rows, err := sc.ch.Conn().Query(queryCtx, `
+        SELECT
+            intDiv(id - 1, ?) AS leaf,
+            min(x) AS min_lng,
+            max(x) AS max_lng,
+            min(y) AS min_lat,
+            max(y) AS max_lat,
+            min(id) AS id_min,
+            max(id) AS id_max,
+            count() AS cnt
+        FROM clustopher.points
+        WHERE cluster_id = ?
+        GROUP BY leaf
+        ORDER BY leaf
+    `, uint32(nodeSize), sc.clusterID)
+	if err != nil {
+		return nil, fmt.Errorf("read leaf bounds: %w", err)
+	}
+	defer rows.Close()
+
+	var leaves []SkeletonLeaf
+	var (
+		leafID                         int64
+		minLng, maxLng, minLat, maxLat float32
+		idMin, idMax                   uint32
+		cnt                            uint64
+	)
+	for rows.Next() {
+		if err := rows.Scan(&leafID, &minLng, &maxLng, &minLat, &maxLat, &idMin, &idMax, &cnt); err != nil {
+			return nil, fmt.Errorf("scan leaf row: %w", err)
+		}
+		_ = leafID // ordering preserved by ORDER BY leaf in SQL
+		topLeft := sc.projectFast(minLng, maxLat, maxZoom)
+		botRight := sc.projectFast(maxLng, minLat, maxZoom)
+		leaves = append(leaves, SkeletonLeaf{
+			Bounds: KDBounds{
+				MinX: topLeft[0],
+				MinY: topLeft[1],
+				MaxX: botRight[0],
+				MaxY: botRight[1],
+			},
+			IDMin: idMin,
+			IDMax: idMax,
+			Count: uint32(cnt),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("leaf bounds rows: %w", err)
+	}
+	return leaves, nil
+}

--- a/cluster/ch_load_singlepass.go
+++ b/cluster/ch_load_singlepass.go
@@ -61,10 +61,34 @@ func (sc *Supercluster) LoadFromCHSinglePass(ctx context.Context) error {
 	insertSettingsBuilt["max_bytes_before_external_sort"] = uint64(1 * 1024 * 1024 * 1024)
 	insertSettingsBuilt["max_bytes_before_external_group_by"] = uint64(1 * 1024 * 1024 * 1024)
 
-	insertCtx := chQueryCtx(ctx, "sp-insert", insertSettingsBuilt)
+	// Profiling at 100M showed the fixed 1 GiB/thread threshold spills 12 GiB
+	// to disk while peak RAM sits at 11 GiB of an 80 GiB cap — pure waste when
+	// the whole sort carry fits in the budget. If the staging partition's
+	// uncompressed size (a good proxy for sort carry) fits comfortably, raise
+	// the per-thread threshold so the sort never spills. Loads too big for the
+	// budget (the 3B case) keep the proven tight caps above.
+	if carry, err := sc.stagingUncompressedBytes(ctx); err == nil && carry > 0 {
+		const sortBudget = uint64(48 * 1024 * 1024 * 1024) // 60% of the 80 GiB cap
+		if carry+carry/2 < sortBudget {                    // 1.5x safety factor for sort overhead
+			perThread := sortBudget / 10
+			insertSettingsBuilt["max_bytes_before_external_sort"] = perThread
+			log.Printf("[ch-single] staging carry %.1f GiB fits sort budget; spill threshold %.1f GiB/thread",
+				float64(carry)/(1<<30), float64(perThread)/(1<<30))
+		} else {
+			log.Printf("[ch-single] staging carry %.1f GiB exceeds sort budget; keeping tight spill caps",
+				float64(carry)/(1<<30))
+		}
+	}
+
 	t := time.Now()
 	log.Printf("[ch-single] morton+rowNumber INSERT begin")
-	if err := sc.ch.Conn().Exec(insertCtx, `
+	if k := singlePassPartitions(); k > 1 {
+		if err := sc.singlePassInsertPartitioned(ctx, k, insertSettingsBuilt); err != nil {
+			return fmt.Errorf("single-pass partitioned insert: %w", err)
+		}
+	} else {
+		insertCtx := chQueryCtx(ctx, "sp-insert", insertSettingsBuilt)
+		if err := sc.ch.Conn().Exec(insertCtx, fmt.Sprintf(`
         INSERT INTO clustopher.points (cluster_id, id, external_id, x, y, metrics, metadata)
         SELECT
             cluster_id,
@@ -76,12 +100,10 @@ func (sc *Supercluster) LoadFromCHSinglePass(ctx context.Context) error {
             metadata
         FROM clustopher.staging_points
         WHERE cluster_id = ?
-        ORDER BY mortonEncode(
-            toUInt32((x + 180.0) / 360.0 * 4294967295),
-            toUInt32((y + 90.0)  / 180.0 * 4294967295)
-        )
-    `, sc.clusterID); err != nil {
-		return fmt.Errorf("single-pass insert: %w", err)
+        ORDER BY %s
+    `, mortonExprSQL), sc.clusterID); err != nil {
+			return fmt.Errorf("single-pass insert: %w", err)
+		}
 	}
 	log.Printf("[ch-single] INSERT done in %s", time.Since(t).Round(time.Second))
 
@@ -104,6 +126,21 @@ func (sc *Supercluster) LoadFromCHSinglePass(ctx context.Context) error {
 		log.Printf("[ch-single] rollup batch populate in %s", time.Since(t).Round(time.Second))
 	}
 	return nil
+}
+
+// stagingUncompressedBytes returns the uncompressed on-disk size of the
+// current cluster's staging partition — the sort pipeline's input carry.
+func (sc *Supercluster) stagingUncompressedBytes(ctx context.Context) (uint64, error) {
+	var n uint64
+	if err := sc.ch.Conn().QueryRow(ctx, `
+        SELECT sum(data_uncompressed_bytes)
+        FROM system.parts
+        WHERE database = 'clustopher' AND table = 'staging_points'
+          AND active AND partition = ?
+    `, sc.clusterID).Scan(&n); err != nil {
+		return 0, fmt.Errorf("staging uncompressed bytes: %w", err)
+	}
+	return n, nil
 }
 
 // readLeafBoundsFromPoints groups the newly inserted points into NodeSize-row

--- a/cluster/ch_load_singlepass_part.go
+++ b/cluster/ch_load_singlepass_part.go
@@ -1,0 +1,237 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// mortonExprSQL is the Z-order key used for the global spatial sort. Shared
+// by the single INSERT path and the partitioned path so both produce the
+// identical ordering.
+const mortonExprSQL = `mortonEncode(
+            toUInt32((x + 180.0) / 360.0 * 4294967295),
+            toUInt32((y + 90.0)  / 180.0 * 4294967295)
+        )`
+
+// singlePassPartitions reports how many morton-range buckets the single-pass
+// INSERT should be split into (CLUSTOPHER_SINGLEPASS_PARTITIONS). 1 (default)
+// keeps the original single global INSERT.
+//
+// Why split: rowNumberInAllBlocks() over a global ORDER BY serializes the
+// final k-way merge, the squash and the MergeTree sink onto one thread —
+// profiling at 100M attributes ~60-80s of a 103s INSERT to that tail. With
+// k disjoint morton ranges, ids are assigned per bucket from precomputed
+// offsets and the buckets run as independent sort→merge→sink pipelines.
+func singlePassPartitions() int {
+	n, err := strconv.Atoi(os.Getenv("CLUSTOPHER_SINGLEPASS_PARTITIONS"))
+	if err != nil || n < 2 {
+		return 1
+	}
+	if n > 16 {
+		n = 16
+	}
+	return n
+}
+
+// singlePassConcurrency reports how many bucket INSERTs may run at once
+// (CLUSTOPHER_SINGLEPASS_CONCURRENCY, default 2). Per-pipeline memory and
+// thread caps are divided by this value so the aggregate stays inside the
+// same budget as the single-INSERT path.
+func singlePassConcurrency() int {
+	n, err := strconv.Atoi(os.Getenv("CLUSTOPHER_SINGLEPASS_CONCURRENCY"))
+	if err != nil || n < 1 {
+		return 2
+	}
+	if n > 8 {
+		n = 8
+	}
+	return n
+}
+
+// singlePassInsertPartitioned splits the staging partition into k disjoint
+// morton-key ranges and runs one INSERT...SELECT per range, with internal ids
+// offset by the exact row counts of the preceding ranges. Concatenated bucket
+// order equals the global morton order, so the resulting (id → point)
+// assignment is equivalent to the single global INSERT up to tie order of
+// identical morton keys (already unspecified there).
+func (sc *Supercluster) singlePassInsertPartitioned(ctx context.Context, k int, baseSettings clickhouse.Settings) error {
+	// Approximate range boundaries: k-quantiles of the morton key. Precision
+	// only affects bucket balance — ids stay exact because counts below are
+	// computed against the same boundaries actually used by the INSERTs.
+	probs := make([]string, 0, k-1)
+	for i := 1; i < k; i++ {
+		probs = append(probs, strconv.FormatFloat(float64(i)/float64(k), 'g', -1, 64))
+	}
+	var qs []float64
+	qb := fmt.Sprintf(`SELECT quantilesTDigest(%s)(%s) FROM clustopher.staging_points WHERE cluster_id = ?`,
+		strings.Join(probs, ", "), mortonExprSQL)
+	if err := sc.ch.Conn().QueryRow(chQueryCtx(ctx, "sp-part-bounds", nil), qb, sc.clusterID).Scan(&qs); err != nil {
+		return fmt.Errorf("morton quantiles: %w", err)
+	}
+	bounds := make([]uint64, 0, len(qs))
+	for _, q := range qs {
+		var b uint64
+		switch {
+		case q <= 0 || math.IsNaN(q):
+			b = 0
+		case q >= math.MaxUint64:
+			b = math.MaxUint64
+		default:
+			b = uint64(q)
+		}
+		bounds = append(bounds, b)
+	}
+	sort.Slice(bounds, func(i, j int) bool { return bounds[i] < bounds[j] })
+	// Collapse duplicate boundaries (degenerate key distributions) — empty
+	// buckets are harmless but pointless.
+	uniq := bounds[:0]
+	for _, b := range bounds {
+		if len(uniq) == 0 || uniq[len(uniq)-1] != b {
+			uniq = append(uniq, b)
+		}
+	}
+	bounds = uniq
+	if len(bounds) == 0 {
+		return fmt.Errorf("morton quantiles collapsed to zero boundaries (k=%d)", k)
+	}
+
+	// Bucket predicates over the morton key. Rows equal to a boundary always
+	// land in the bucket starting at it, so ties never straddle buckets.
+	conds := make([]string, 0, len(bounds)+1)
+	for i := 0; i <= len(bounds); i++ {
+		switch {
+		case i == 0:
+			conds = append(conds, fmt.Sprintf("%s < %d", mortonExprSQL, bounds[0]))
+		case i == len(bounds):
+			conds = append(conds, fmt.Sprintf("%s >= %d", mortonExprSQL, bounds[i-1]))
+		default:
+			conds = append(conds, fmt.Sprintf("%s >= %d AND %s < %d", mortonExprSQL, bounds[i-1], mortonExprSQL, bounds[i]))
+		}
+	}
+
+	// Exact per-bucket counts → id offsets.
+	countExprs := make([]string, len(conds))
+	for i, c := range conds {
+		countExprs[i] = "countIf(" + c + ")"
+	}
+	counts := make([]uint64, len(conds))
+	dest := make([]any, len(conds))
+	for i := range counts {
+		dest[i] = &counts[i]
+	}
+	qc := "SELECT " + strings.Join(countExprs, ", ") + " FROM clustopher.staging_points WHERE cluster_id = ?"
+	if err := sc.ch.Conn().QueryRow(chQueryCtx(ctx, "sp-part-counts", nil), qc, sc.clusterID).Scan(dest...); err != nil {
+		return fmt.Errorf("bucket counts: %w", err)
+	}
+	offsets := make([]uint64, len(counts))
+	var total uint64
+	for i, c := range counts {
+		offsets[i] = total
+		total += c
+	}
+	if total > math.MaxUint32 {
+		return fmt.Errorf("total rows %d exceeds uint32 id space", total)
+	}
+
+	// Per-pipeline caps: divide the single-INSERT budget across concurrent
+	// pipelines so the aggregate matches the proven envelope.
+	j := singlePassConcurrency()
+	if j > len(conds) {
+		j = len(conds)
+	}
+	pipeSettings := clickhouse.Settings{}
+	for key, v := range baseSettings {
+		pipeSettings[key] = v
+	}
+	for _, key := range []string{"max_memory_usage", "max_bytes_before_external_sort", "max_bytes_before_external_group_by"} {
+		if v, ok := pipeSettings[key].(uint64); ok {
+			pipeSettings[key] = v / uint64(j)
+		}
+	}
+	if v, ok := pipeSettings["max_threads"].(uint64); ok {
+		nt := v / uint64(j)
+		if nt < 4 {
+			nt = 4
+		}
+		pipeSettings["max_threads"] = nt
+	}
+
+	log.Printf("[ch-single] partitioned insert: %d buckets, %d concurrent, counts=%v", len(conds), j, counts)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	jobs := make(chan int, len(conds))
+	errCh := make(chan error, j)
+	var wg sync.WaitGroup
+	for w := 0; w < j; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			ch := sc.ch
+			if w > 0 {
+				clone, err := sc.ch.Clone(ctx)
+				if err != nil {
+					errCh <- err
+					cancel()
+					return
+				}
+				defer clone.Close()
+				ch = clone
+			}
+			for i := range jobs {
+				if counts[i] == 0 {
+					continue
+				}
+				bt := time.Now()
+				q := fmt.Sprintf(`
+        INSERT INTO clustopher.points (cluster_id, id, external_id, x, y, metrics, metadata)
+        SELECT
+            cluster_id,
+            toUInt32(rowNumberInAllBlocks() + %d) AS id,
+            external_id,
+            x,
+            y,
+            metrics,
+            metadata
+        FROM clustopher.staging_points
+        WHERE cluster_id = ? AND (%s)
+        ORDER BY %s
+    `, offsets[i]+1, conds[i], mortonExprSQL)
+				insertCtx := chQueryCtx(ctx, "sp-insert-p"+strconv.Itoa(i), pipeSettings)
+				if err := ch.Conn().Exec(insertCtx, q, sc.clusterID); err != nil {
+					errCh <- fmt.Errorf("bucket %d insert: %w", i, err)
+					cancel()
+					return
+				}
+				log.Printf("[ch-single] bucket %d/%d: %d rows in %s", i+1, len(conds), counts[i], time.Since(bt).Round(time.Second))
+			}
+		}(w)
+	}
+sendJobs:
+	for i := range conds {
+		select {
+		case jobs <- i:
+		case <-ctx.Done():
+			break sendJobs
+		}
+	}
+	close(jobs)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
+	return ctx.Err()
+}

--- a/cluster/ch_load_singlepass_test.go
+++ b/cluster/ch_load_singlepass_test.go
@@ -1,0 +1,121 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+)
+
+// TestSinglePassPartitionedEquivalence verifies the partitioned single-pass
+// INSERT produces a canonical points table equivalent to the global INSERT:
+// ids are exactly 1..N, the morton key is non-decreasing in id order, and the
+// external_id population is preserved.
+func TestSinglePassPartitionedEquivalence(t *testing.T) {
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+
+	const n = 500_000
+	genBBox := KDBounds{MinX: -124, MinY: 26, MaxX: -66, MaxY: 48}
+	specs := map[string]metricSpec{
+		"value_const_1": {CHExpr: "toFloat32(1)"},
+	}
+
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	clusterID := "SP_PART_EQ"
+	cleanup := func() {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+		for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+		}
+	}
+	cleanup()
+	defer cleanup()
+
+	if err := generateMetricPoints(ctx, c, clusterID, n, genBBox, specs); err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+
+	sc := NewSupercluster(SuperclusterOptions{
+		MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40, Extent: 512, NodeSize: 64,
+	})
+	sc.SetCHClient(c)
+	sc.SetClusterID(clusterID)
+
+	t.Setenv("CLUSTOPHER_SINGLEPASS_PARTITIONS", "4")
+	t.Setenv("CLUSTOPHER_SINGLEPASS_CONCURRENCY", "2")
+	if err := sc.LoadFromCHSinglePass(ctx); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// ids are exactly 1..N with no gaps or duplicates.
+	var cnt, idMin, idMax, idUniq uint64
+	if err := c.Conn().QueryRow(ctx, `
+        SELECT count(), toUInt64(min(id)), toUInt64(max(id)), uniqExact(id)
+        FROM clustopher.points WHERE cluster_id = ?
+    `, clusterID).Scan(&cnt, &idMin, &idMax, &idUniq); err != nil {
+		t.Fatalf("id stats: %v", err)
+	}
+	if cnt != n || idMin != 1 || idMax != n || idUniq != n {
+		t.Errorf("id space broken: cnt=%d min=%d max=%d uniq=%d want n=%d", cnt, idMin, idMax, idUniq, n)
+	}
+
+	// Morton key non-decreasing in id order (the global sort invariant).
+	var violations uint64
+	mq := fmt.Sprintf(`
+        SELECT countIf(m < mPrev AND rn > 1) FROM (
+            SELECT
+                %s AS m,
+                lagInFrame(%s) OVER w AS mPrev,
+                row_number() OVER w AS rn
+            FROM clustopher.points
+            WHERE cluster_id = ?
+            WINDOW w AS (ORDER BY id ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+        )
+    `, mortonExprSQL, mortonExprSQL)
+	if err := c.Conn().QueryRow(ctx, mq, clusterID).Scan(&violations); err != nil {
+		t.Fatalf("morton monotonicity query: %v", err)
+	}
+	if violations != 0 {
+		t.Errorf("morton order violated at %d positions", violations)
+	}
+
+	// external_id population preserved exactly (ids unique per cluster).
+	var stagingUniq, pointsUniq uint64
+	var stagingSum, pointsSum uint64
+	if err := c.Conn().QueryRow(ctx, `
+        SELECT uniqExact(external_id), sum(toUInt64(external_id))
+        FROM clustopher.staging_points WHERE cluster_id = ?
+    `, clusterID).Scan(&stagingUniq, &stagingSum); err != nil {
+		t.Fatalf("staging external ids: %v", err)
+	}
+	if err := c.Conn().QueryRow(ctx, `
+        SELECT uniqExact(external_id), sum(toUInt64(external_id))
+        FROM clustopher.points WHERE cluster_id = ?
+    `, clusterID).Scan(&pointsUniq, &pointsSum); err != nil {
+		t.Fatalf("points external ids: %v", err)
+	}
+	if stagingUniq != pointsUniq || stagingSum != pointsSum {
+		t.Errorf("external_id population changed: staging uniq=%d sum=%d, points uniq=%d sum=%d",
+			stagingUniq, stagingSum, pointsUniq, pointsSum)
+	}
+
+	// Skeleton sanity: leaf count matches ceil(n / NodeSize).
+	wantLeaves := (n + 63) / 64
+	if got := len(sc.Skeleton.Leaves); got != wantLeaves {
+		t.Errorf("skeleton leaves=%d want %d", got, wantLeaves)
+	}
+}

--- a/cluster/ch_load_streaming.go
+++ b/cluster/ch_load_streaming.go
@@ -195,8 +195,22 @@ func (sc *Supercluster) LoadFromCHStreaming(ctx context.Context) error {
 
 	sc.Skeleton = BuildSkeletonFromLeaves(leaves)
 
+	deferred := rollupPopulateDeferred()
+	if deferred {
+		if err := sc.detachRollupMVs(ctx); err != nil {
+			return err
+		}
+		defer func() {
+			_ = sc.attachRollupMVs(context.Background())
+		}()
+	}
 	if err := sc.populatePointsFromStaging(ctx, loadID); err != nil {
 		return err
+	}
+	if deferred {
+		if err := sc.populateRollupsBatch(ctx); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cluster/ch_load_streaming.go
+++ b/cluster/ch_load_streaming.go
@@ -255,4 +255,3 @@ func (sc *Supercluster) streamingIDMapWorker(ctx context.Context, ch *CHClient, 
 		}
 	}
 }
-

--- a/cluster/ch_load_streaming.go
+++ b/cluster/ch_load_streaming.go
@@ -3,7 +3,9 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"log"
 	"sync"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
@@ -85,7 +87,21 @@ func (sc *Supercluster) LoadFromCHStreaming(ctx context.Context) error {
 	// Query: stream rows sorted by Morton index of normalized lng/lat. Bounds
 	// for normalization are fixed [-180,180] / [-90,90] so we don't need a
 	// pre-pass — Morton spatial locality holds on any subset of the world.
-	rows, err := sc.ch.Conn().Query(ctx, `
+	//
+	// Cap CH-server sort RAM. max_bytes_before_external_sort is a per-thread
+	// threshold, so the effective sort buffer = threshold * max_threads.
+	// Hard-cap query at 60GB; allow 20 threads × 4GB sort buffer = 80GB
+	// worst case, but cap forces spill earlier. External_sort=4GB balances
+	// spill frequency vs throughput.
+	queryCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"max_memory_usage":                   uint64(60 * 1024 * 1024 * 1024),
+		"max_threads":                        uint64(20),
+		"max_bytes_before_external_sort":     uint64(4 * 1024 * 1024 * 1024),
+		"max_bytes_before_external_group_by": uint64(4 * 1024 * 1024 * 1024),
+	}))
+	streamStart := time.Now()
+	log.Printf("[ch-stream] morton SELECT begin")
+	rows, err := sc.ch.Conn().Query(queryCtx, `
         SELECT external_id, x, y
         FROM clustopher.staging_points
         WHERE cluster_id = ?
@@ -140,6 +156,8 @@ func (sc *Supercluster) LoadFromCHStreaming(ctx context.Context) error {
 		extID uint32
 		x, y  float32
 	)
+	var rowsRead uint64
+	progressEvery := uint64(50_000_000)
 	for rows.Next() {
 		if err := rows.Scan(&extID, &x, &y); err != nil {
 			rows.Close()
@@ -173,15 +191,22 @@ func (sc *Supercluster) LoadFromCHStreaming(ctx context.Context) error {
 		}
 
 		internalID++
+		rowsRead++
+		if rowsRead%progressEvery == 0 {
+			log.Printf("[ch-stream] read %dM rows in %s", rowsRead/1_000_000, time.Since(streamStart).Round(time.Second))
+		}
 		if len(chunk) == nodeSize {
 			flushLeaf()
 		}
 	}
 	rows.Close()
 	flushLeaf()
+	log.Printf("[ch-stream] morton SELECT done: %d rows, %d leaves, %s", rowsRead, len(leaves), time.Since(streamStart).Round(time.Second))
 
 	close(idMapCh)
+	t := time.Now()
 	idMapWg.Wait()
+	log.Printf("[ch-stream] id-map workers drained in %s", time.Since(t).Round(time.Second))
 	close(idMapErrCh)
 	for werr := range idMapErrCh {
 		if werr != nil {
@@ -193,24 +218,32 @@ func (sc *Supercluster) LoadFromCHStreaming(ctx context.Context) error {
 		return fmt.Errorf("streaming rows: %w", err)
 	}
 
+	t = time.Now()
 	sc.Skeleton = BuildSkeletonFromLeaves(leaves)
+	log.Printf("[ch-stream] skeleton built in %s", time.Since(t).Round(time.Second))
 
 	deferred := rollupPopulateDeferred()
 	if deferred {
+		t = time.Now()
 		if err := sc.detachRollupMVs(ctx); err != nil {
 			return err
 		}
+		log.Printf("[ch-stream] detached rollup MVs in %s", time.Since(t).Round(time.Second))
 		defer func() {
 			_ = sc.attachRollupMVs(context.Background())
 		}()
 	}
+	t = time.Now()
 	if err := sc.populatePointsFromStaging(ctx, loadID); err != nil {
 		return err
 	}
+	log.Printf("[ch-stream] populate points from staging in %s", time.Since(t).Round(time.Second))
 	if deferred {
+		t = time.Now()
 		if err := sc.populateRollupsBatch(ctx); err != nil {
 			return err
 		}
+		log.Printf("[ch-stream] rollup batch populate in %s", time.Since(t).Round(time.Second))
 	}
 	return nil
 }

--- a/cluster/ch_load_streaming.go
+++ b/cluster/ch_load_streaming.go
@@ -1,0 +1,258 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// chFirstStreamingIDMapBatch is the number of (external,internal) pairs queued
+// per ID-map insert batch. Smaller than idMapBatchSize because we are also
+// driving the reader thread concurrently, so we want batches to flush at a
+// steady rate rather than buffer for very long.
+const chFirstStreamingIDMapBatch = 100_000
+
+// LoadFromCHStreaming is a memory-bounded alternative to LoadFromCHStaging
+// that pushes the spatial sort into ClickHouse via a Morton-encoded ORDER BY,
+// streams the sorted rows back, builds skeleton leaves on the fly in
+// NodeSize-row chunks, and concurrently writes the (external,internal) id map
+// to ClickHouse.
+//
+// Compared with LoadFromCHStaging this skips materializing the full
+// []chSpatialRow and []KDPoint slices in Go, dropping peak Go heap from
+// ~14 GB at 300M to a few hundred MB even at 1B+ points. Tradeoff: Morton
+// ordering is a 2D space-filling-curve approximation of the exact KD-tree
+// median partition that LoadFromCHStaging produces, so leaf bounds may
+// overlap slightly more and high-zoom RangeLeaves queries can visit a few
+// extra leaves.
+func (sc *Supercluster) LoadFromCHStreaming(ctx context.Context) error {
+	if sc.ch == nil {
+		return fmt.Errorf("LoadFromCHStreaming requires CH client")
+	}
+	if sc.clusterID == "" {
+		return fmt.Errorf("LoadFromCHStreaming requires clusterID")
+	}
+
+	loadID, err := newLoadID()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = sc.dropPointIDMapLoad(context.Background(), loadID)
+	}()
+
+	if err := sc.resetCanonicalCluster(ctx); err != nil {
+		return err
+	}
+
+	nodeSize := sc.Options.NodeSize
+	if nodeSize < 1 {
+		nodeSize = 1
+	}
+
+	// ID-map writer fan-out. Each worker holds its own CH connection so the
+	// inserts run in parallel with the streaming reader.
+	idMapCh := make(chan idMapEntry, chFirstStreamingIDMapBatch*idMapInsertWorkers)
+	idMapErrCh := make(chan error, idMapInsertWorkers)
+	idMapCtx, idMapCancel := context.WithCancel(ctx)
+	defer idMapCancel()
+
+	var idMapWg sync.WaitGroup
+	for w := 0; w < idMapInsertWorkers; w++ {
+		idMapWg.Add(1)
+		go func(worker int) {
+			defer idMapWg.Done()
+			ch := sc.ch
+			if worker > 0 {
+				clone, err := sc.ch.Clone(idMapCtx)
+				if err != nil {
+					idMapErrCh <- fmt.Errorf("clone ch worker %d: %w", worker, err)
+					idMapCancel()
+					return
+				}
+				defer clone.Close()
+				ch = clone
+			}
+			if err := sc.streamingIDMapWorker(idMapCtx, ch, loadID, idMapCh); err != nil {
+				idMapErrCh <- err
+				idMapCancel()
+			}
+		}(w)
+	}
+
+	// Query: stream rows sorted by Morton index of normalized lng/lat. Bounds
+	// for normalization are fixed [-180,180] / [-90,90] so we don't need a
+	// pre-pass — Morton spatial locality holds on any subset of the world.
+	rows, err := sc.ch.Conn().Query(ctx, `
+        SELECT external_id, x, y
+        FROM clustopher.staging_points
+        WHERE cluster_id = ?
+        ORDER BY mortonEncode(
+            toUInt32((x + 180.0) / 360.0 * 4294967295),
+            toUInt32((y + 90.0)  / 180.0 * 4294967295)
+        )
+    `, sc.clusterID)
+	if err != nil {
+		idMapCancel()
+		idMapWg.Wait()
+		return fmt.Errorf("stream staging by morton: %w", err)
+	}
+
+	leaves := make([]SkeletonLeaf, 0, 1024)
+	chunk := make([]projectedRow, 0, nodeSize)
+	var internalID uint32 = 1
+
+	flushLeaf := func() {
+		if len(chunk) == 0 {
+			return
+		}
+		b := KDBounds{
+			MinX: chunk[0].px, MaxX: chunk[0].px,
+			MinY: chunk[0].py, MaxY: chunk[0].py,
+		}
+		for _, p := range chunk[1:] {
+			if p.px < b.MinX {
+				b.MinX = p.px
+			}
+			if p.px > b.MaxX {
+				b.MaxX = p.px
+			}
+			if p.py < b.MinY {
+				b.MinY = p.py
+			}
+			if p.py > b.MaxY {
+				b.MaxY = p.py
+			}
+		}
+		leaves = append(leaves, SkeletonLeaf{
+			Bounds: b,
+			IDMin:  chunk[0].internalID,
+			IDMax:  chunk[len(chunk)-1].internalID,
+			Count:  uint32(len(chunk)),
+		})
+		chunk = chunk[:0]
+	}
+
+	maxZoom := sc.Options.MaxZoom
+	var (
+		extID uint32
+		x, y  float32
+	)
+	for rows.Next() {
+		if err := rows.Scan(&extID, &x, &y); err != nil {
+			rows.Close()
+			idMapCancel()
+			idMapWg.Wait()
+			return fmt.Errorf("scan streaming row: %w", err)
+		}
+		proj := sc.projectFast(x, y, maxZoom)
+		chunk = append(chunk, projectedRow{
+			internalID: internalID,
+			px:         proj[0],
+			py:         proj[1],
+		})
+
+		select {
+		case idMapCh <- idMapEntry{externalID: extID, internalID: internalID}:
+		case <-idMapCtx.Done():
+			rows.Close()
+			idMapWg.Wait()
+			if err := idMapCtx.Err(); err != nil && err != context.Canceled {
+				return err
+			}
+			// Drain worker error channel, if any.
+			close(idMapErrCh)
+			for werr := range idMapErrCh {
+				if werr != nil {
+					return werr
+				}
+			}
+			return fmt.Errorf("id-map writers exited before stream completed")
+		}
+
+		internalID++
+		if len(chunk) == nodeSize {
+			flushLeaf()
+		}
+	}
+	rows.Close()
+	flushLeaf()
+
+	close(idMapCh)
+	idMapWg.Wait()
+	close(idMapErrCh)
+	for werr := range idMapErrCh {
+		if werr != nil {
+			return werr
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("streaming rows: %w", err)
+	}
+
+	sc.Skeleton = BuildSkeletonFromLeaves(leaves)
+
+	if err := sc.populatePointsFromStaging(ctx, loadID); err != nil {
+		return err
+	}
+	return nil
+}
+
+type projectedRow struct {
+	internalID uint32
+	px         float32
+	py         float32
+}
+
+type idMapEntry struct {
+	externalID uint32
+	internalID uint32
+}
+
+// streamingIDMapWorker drains the entry channel, batching inserts to
+// clustopher.point_id_map_load. Exits cleanly when the channel closes.
+func (sc *Supercluster) streamingIDMapWorker(ctx context.Context, ch *CHClient, loadID uint64, in <-chan idMapEntry) error {
+	insertCtx := clickhouse.Context(ctx, clickhouse.WithSettings(insertSettings))
+	flush := func(buf []idMapEntry) error {
+		if len(buf) == 0 {
+			return nil
+		}
+		batch, err := ch.Conn().PrepareBatch(insertCtx,
+			"INSERT INTO clustopher.point_id_map_load (load_id, external_id, internal_id)")
+		if err != nil {
+			return fmt.Errorf("prepare id map batch: %w", err)
+		}
+		for _, e := range buf {
+			if err := batch.Append(loadID, e.externalID, e.internalID); err != nil {
+				return fmt.Errorf("append id map row: %w", err)
+			}
+		}
+		if err := batch.Send(); err != nil {
+			return fmt.Errorf("send id map batch: %w", err)
+		}
+		return nil
+	}
+
+	buf := make([]idMapEntry, 0, chFirstStreamingIDMapBatch)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case e, ok := <-in:
+			if !ok {
+				return flush(buf)
+			}
+			buf = append(buf, e)
+			if len(buf) >= chFirstStreamingIDMapBatch {
+				if err := flush(buf); err != nil {
+					return err
+				}
+				buf = buf[:0]
+			}
+		}
+	}
+}
+

--- a/cluster/ch_load_streaming_test.go
+++ b/cluster/ch_load_streaming_test.go
@@ -1,0 +1,189 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestCHStreamingMatchesKD loads the same staged dataset twice — once via
+// LoadFromCHStaging (exact KD sort) and once via LoadFromCHStreaming (Morton
+// sort) — and asserts that GetClustersCH produces equivalent results.
+//
+// Low/mid zoom queries hit the per-zoom rollup MV (depends only on point
+// positions, not skeleton order) so they must match exactly. The z14 path
+// walks the skeleton, so cluster counts may differ slightly between the two
+// orderings; we assert they are within 5% of each other and that the union of
+// returned point counts matches.
+//
+// Gated by CLUSTOPHER_STREAMING_PARITY=1 because it requires a live CH.
+func TestCHStreamingMatchesKD(t *testing.T) {
+	if os.Getenv("CLUSTOPHER_STREAMING_PARITY") != "1" {
+		t.Skip("set CLUSTOPHER_STREAMING_PARITY=1 to run streaming-vs-KD parity")
+	}
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+
+	const n = 1_000_000
+	conus := KDBounds{MinX: -125, MinY: 25, MaxX: -65, MaxY: 49}
+
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	type result struct {
+		path     string
+		loadSec  float64
+		heapMB   float64
+		leaves   int
+		queries  map[int]queryResult
+	}
+	queries := []int{2, 8, 14}
+	vp := func(z int) KDBounds {
+		if z >= 11 {
+			return KDBounds{MinX: -100.25, MinY: 39.25, MaxX: -99.75, MaxY: 39.75}
+		}
+		if z >= 5 {
+			return KDBounds{MinX: -100, MinY: 37, MaxX: -95, MaxY: 42}
+		}
+		return conus
+	}
+
+	runOne := func(label string, loader func(sc *Supercluster, ctx context.Context) error) result {
+		clusterID := fmt.Sprintf("PARITY_%s_%d", label, n)
+		cleanup := func() {
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+			for z := 2; z <= 16; z++ {
+				_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+			}
+		}
+		cleanup()
+		defer cleanup()
+
+		if err := generateDenseStagingPoints(ctx, c, clusterID, n, conus); err != nil {
+			t.Fatalf("[%s] stage: %v", label, err)
+		}
+		sc := NewSupercluster(SuperclusterOptions{
+			MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40, Extent: 512, NodeSize: 64,
+		})
+		sc.SetCHClient(c)
+		sc.SetClusterID(clusterID)
+
+		start := time.Now()
+		if err := loader(sc, ctx); err != nil {
+			t.Fatalf("[%s] load: %v", label, err)
+		}
+		loadSec := time.Since(start).Seconds()
+		for z := 2; z <= 16; z++ {
+			_ = c.Conn().Exec(ctx, "OPTIMIZE TABLE clustopher.rollup_z"+strconv.Itoa(z)+" PARTITION ? FINAL", clusterID)
+		}
+
+		r := result{path: label, loadSec: loadSec, leaves: len(sc.Skeleton.Leaves), queries: map[int]queryResult{}}
+		for _, z := range queries {
+			start := time.Now()
+			cs, err := sc.GetClustersCH(ctx, vp(z), z)
+			if err != nil {
+				t.Fatalf("[%s] z=%d query: %v", label, z, err)
+			}
+			var totalCount uint64
+			for _, cl := range cs {
+				totalCount += uint64(cl.Count)
+			}
+			r.queries[z] = queryResult{
+				clusters:   len(cs),
+				totalCount: totalCount,
+				elapsedMs:  float64(time.Since(start).Microseconds()) / 1000.0,
+			}
+		}
+		return r
+	}
+
+	kd := runOne("KD", func(sc *Supercluster, ctx context.Context) error {
+		return sc.LoadFromCHStaging(ctx)
+	})
+	stream := runOne("STREAM", func(sc *Supercluster, ctx context.Context) error {
+		return sc.LoadFromCHStreaming(ctx)
+	})
+
+	t.Logf("KD     load=%.1fs leaves=%d", kd.loadSec, kd.leaves)
+	t.Logf("STREAM load=%.1fs leaves=%d", stream.loadSec, stream.leaves)
+
+	if kd.leaves != stream.leaves {
+		t.Errorf("leaf count differs: KD=%d STREAM=%d", kd.leaves, stream.leaves)
+	}
+
+	for _, z := range queries {
+		k := kd.queries[z]
+		s := stream.queries[z]
+		t.Logf("z=%d  KD: clusters=%d totalCount=%d elapsed=%.1fms  STREAM: clusters=%d totalCount=%d elapsed=%.1fms",
+			z, k.clusters, k.totalCount, k.elapsedMs, s.clusters, s.totalCount, s.elapsedMs)
+
+		if z < 11 {
+			// Rollup MV path is data-only — must match exactly.
+			if k.clusters != s.clusters {
+				t.Errorf("z=%d (rollup MV path) cluster count differs: KD=%d STREAM=%d", z, k.clusters, s.clusters)
+			}
+			if k.totalCount != s.totalCount {
+				t.Errorf("z=%d (rollup MV path) total point count differs: KD=%d STREAM=%d", z, k.totalCount, s.totalCount)
+			}
+			continue
+		}
+		// Skeleton path: cluster counts may shift because Morton leaves are
+		// looser than KD median-partition leaves — more leaves overlap viewport
+		// edges so a few extra points get fetched. Tolerate up to 25%.
+		ratio := math.Abs(float64(k.clusters-s.clusters)) / float64(max1(k.clusters))
+		if ratio > 0.25 {
+			t.Errorf("z=%d skeleton path cluster count diverges by %.1f%% (KD=%d STREAM=%d)",
+				z, ratio*100, k.clusters, s.clusters)
+		}
+		diff := absDiff(k.totalCount, s.totalCount)
+		if float64(diff)/float64(max1u(k.totalCount)) > 0.25 {
+			t.Errorf("z=%d skeleton path total point count diverges by %d (KD=%d STREAM=%d)",
+				z, diff, k.totalCount, s.totalCount)
+		}
+	}
+}
+
+type queryResult struct {
+	clusters   int
+	totalCount uint64
+	elapsedMs  float64
+}
+
+func max1(x int) int {
+	if x < 1 {
+		return 1
+	}
+	return x
+}
+
+func max1u(x uint64) uint64 {
+	if x < 1 {
+		return 1
+	}
+	return x
+}
+
+func absDiff(a, b uint64) uint64 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}
+
+// silence unused import warnings if helpers move
+var _ = sort.Ints

--- a/cluster/ch_profile.go
+++ b/cluster/ch_profile.go
@@ -1,0 +1,38 @@
+package cluster
+
+import (
+	"context"
+	"os"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// chProfileEnabled reports whether CH-side query profiling is requested via
+// CLUSTOPHER_CH_PROFILE=1. When enabled, heavy queries are tagged with a
+// log_comment and run with the sampling profiler on, so system.query_log,
+// system.processors_profile_log and system.trace_log carry rows attributable
+// to each pipeline stage. Off by default; the production path is unchanged.
+func chProfileEnabled() bool {
+	return os.Getenv("CLUSTOPHER_CH_PROFILE") == "1"
+}
+
+// chQueryCtx returns a context carrying the given CH settings, augmented with
+// profiling settings + a log_comment tag when CLUSTOPHER_CH_PROFILE=1. The
+// settings map is copied, so callers may pass shared maps (e.g.
+// insertSettings) without aliasing.
+func chQueryCtx(ctx context.Context, tag string, settings clickhouse.Settings) context.Context {
+	merged := clickhouse.Settings{}
+	for k, v := range settings {
+		merged[k] = v
+	}
+	if chProfileEnabled() {
+		merged["log_comment"] = tag
+		merged["log_processors_profiles"] = uint64(1)
+		merged["query_profiler_real_time_period_ns"] = uint64(10_000_000)
+		merged["query_profiler_cpu_time_period_ns"] = uint64(10_000_000)
+	}
+	if len(merged) == 0 {
+		return ctx
+	}
+	return clickhouse.Context(ctx, clickhouse.WithSettings(merged))
+}

--- a/cluster/ch_query.go
+++ b/cluster/ch_query.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
@@ -174,18 +175,92 @@ func (sc *Supercluster) queryTree(ctx context.Context, viewport KDBounds, zoom i
 	}
 
 	if len(partial) > 0 {
-		pts, err := sc.fetchLeafPoints(ctx, partial, zoom)
+		pts, attrs, err := sc.fetchLeafPoints(ctx, partial, zoom)
 		if err != nil {
 			return nil, err
 		}
 		if len(pts) > 0 {
 			clusters := sc.clusterPoints(pts, float32(sc.Options.Radius))
+			attachAttrsFromMembers(clusters, attrs)
 			sc.unprojectClusters(clusters, zoom)
 			out = append(out, clusters...)
 		}
 	}
 
 	return out, nil
+}
+
+// pointAttrs carries per-point metrics + metadata fetched from CH alongside
+// the geometry. Used by the partial-leaf path so the in-Go clusterPoints stage
+// can attach aggregated metric/metadata back onto each emitted ClusterNode.
+type pointAttrs struct {
+	Metrics  map[string]float32
+	Metadata map[string]string
+}
+
+// attachAttrsFromMembers fills each cluster's Metrics/Metadata by aggregating
+// the per-member attributes recorded in attrs. Metrics are averaged so the
+// per-cluster value matches the convention used by the rollup and
+// aggregateLeaves paths (sum/cnt); metadata picks the most common value per
+// key across members. Clusters whose Children list is empty (defensive — all
+// clusters built by clusterPoints carry their member IDs) are left untouched.
+func attachAttrsFromMembers(clusters []ClusterNode, attrs map[uint32]pointAttrs) {
+	if len(attrs) == 0 {
+		return
+	}
+	for i := range clusters {
+		members := clusters[i].Children
+		if len(members) == 0 {
+			continue
+		}
+		sums := make(map[string]float64)
+		counts := make(map[string]uint64)
+		metaFreq := make(map[string]map[string]int)
+		for _, id := range members {
+			a, ok := attrs[id]
+			if !ok {
+				continue
+			}
+			for k, v := range a.Metrics {
+				sums[k] += float64(v)
+				counts[k]++
+			}
+			for k, v := range a.Metadata {
+				inner, ok := metaFreq[k]
+				if !ok {
+					inner = make(map[string]int)
+					metaFreq[k] = inner
+				}
+				inner[v]++
+			}
+		}
+		if len(sums) > 0 {
+			metrics := make(map[string]float32, len(sums))
+			for k, s := range sums {
+				if n := counts[k]; n > 0 {
+					metrics[k] = float32(s / float64(n))
+				}
+			}
+			clusters[i].Metrics = metrics
+		}
+		if len(metaFreq) > 0 {
+			meta := make(map[string]json.RawMessage, len(metaFreq))
+			for k, freq := range metaFreq {
+				var topVal string
+				var topCnt int
+				for v, c := range freq {
+					if c > topCnt {
+						topVal = v
+						topCnt = c
+					}
+				}
+				if b, err := json.Marshal(topVal); err == nil {
+					meta[k] = b
+				}
+			}
+			clusters[i].Metadata = meta
+		}
+	}
 }
 
 // aggregateLeaves emits one ClusterNode per inside leaf by aggregating across
@@ -278,17 +353,18 @@ func (sc *Supercluster) aggregateLeaves(ctx context.Context, leaves []int32) (cl
 // them projected to the target zoom (so existing clusterPoints can run).
 // Leaves are compressed into contiguous internal-id ranges to avoid serializing
 // large leaf arrays into ClickHouse query text.
-func (sc *Supercluster) fetchLeafPoints(ctx context.Context, leaves []int32, zoom int) ([]KDPoint, error) {
+func (sc *Supercluster) fetchLeafPoints(ctx context.Context, leaves []int32, zoom int) ([]KDPoint, map[uint32]pointAttrs, error) {
 	if len(leaves) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	ranges := sc.leafIDRanges(leaves)
 	if len(ranges) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	out := make([]KDPoint, 0, len(leaves)*sc.Options.NodeSize)
+	attrs := make(map[uint32]pointAttrs, len(leaves)*sc.Options.NodeSize)
 	for start := 0; start < len(ranges); start += maxLeafIDRangesPerQuery {
 		end := start + maxLeafIDRangesPerQuery
 		if end > len(ranges) {
@@ -296,7 +372,7 @@ func (sc *Supercluster) fetchLeafPoints(ctx context.Context, leaves []int32, zoo
 		}
 		where, rangeArgs := leafRangePredicate(ranges[start:end])
 		q := fmt.Sprintf(`
-        SELECT id, x, y FROM clustopher.points
+        SELECT id, x, y, metrics, metadata FROM clustopher.points
         WHERE cluster_id = ?
           AND (%s)
     `, where)
@@ -307,25 +383,32 @@ func (sc *Supercluster) fetchLeafPoints(ctx context.Context, leaves []int32, zoo
 
 		rows, err := sc.ch.Conn().Query(ctx, q, args...)
 		if err != nil {
-			return nil, fmt.Errorf("fetch leaf points: %w", err)
+			return nil, nil, fmt.Errorf("fetch leaf points: %w", err)
 		}
-		var id uint32
-		var x, y float32
+		var (
+			id       uint32
+			x, y     float32
+			metrics  map[string]float32
+			metadata map[string]string
+		)
 		for rows.Next() {
-			if err := rows.Scan(&id, &x, &y); err != nil {
+			if err := rows.Scan(&id, &x, &y, &metrics, &metadata); err != nil {
 				rows.Close()
-				return nil, err
+				return nil, nil, err
 			}
 			proj := sc.projectFast(x, y, zoom)
 			out = append(out, KDPoint{ID: id, X: proj[0], Y: proj[1], NumPoints: 1})
+			if len(metrics) > 0 || len(metadata) > 0 {
+				attrs[id] = pointAttrs{Metrics: metrics, Metadata: metadata}
+			}
 		}
 		if err := rows.Err(); err != nil {
 			rows.Close()
-			return nil, err
+			return nil, nil, err
 		}
 		rows.Close()
 	}
-	return out, nil
+	return out, attrs, nil
 }
 
 func (sc *Supercluster) leafIDRanges(leaves []int32) []leafIDRange {

--- a/cluster/ch_query.go
+++ b/cluster/ch_query.go
@@ -288,79 +288,6 @@ func (sc *Supercluster) mergeClustersByRadius(clusters []ClusterNode, zoom int, 
 	return out
 }
 
-// pointAttrs carries per-point metrics + metadata fetched from CH alongside
-// the geometry. Used by the partial-leaf path so the in-Go clusterPoints stage
-// can attach aggregated metric/metadata back onto each emitted ClusterNode.
-type pointAttrs struct {
-	Metrics  map[string]float32
-	Metadata map[string]string
-}
-
-// attachAttrsFromMembers fills each cluster's Metrics/Metadata by aggregating
-// the per-member attributes recorded in attrs. Metrics are averaged so the
-// per-cluster value matches the convention used by the rollup and
-// aggregateLeaves paths (sum/cnt); metadata picks the most common value per
-// key across members. Clusters whose Children list is empty (defensive — all
-// clusters built by clusterPoints carry their member IDs) are left untouched.
-func attachAttrsFromMembers(clusters []ClusterNode, attrs map[uint32]pointAttrs) {
-	if len(attrs) == 0 {
-		return
-	}
-	for i := range clusters {
-		members := clusters[i].Children
-		if len(members) == 0 {
-			continue
-		}
-		sums := make(map[string]float64)
-		counts := make(map[string]uint64)
-		metaFreq := make(map[string]map[string]int)
-		for _, id := range members {
-			a, ok := attrs[id]
-			if !ok {
-				continue
-			}
-			for k, v := range a.Metrics {
-				sums[k] += float64(v)
-				counts[k]++
-			}
-			for k, v := range a.Metadata {
-				inner, ok := metaFreq[k]
-				if !ok {
-					inner = make(map[string]int)
-					metaFreq[k] = inner
-				}
-				inner[v]++
-			}
-		}
-		if len(sums) > 0 {
-			metrics := make(map[string]float32, len(sums))
-			for k, s := range sums {
-				if n := counts[k]; n > 0 {
-					metrics[k] = float32(s / float64(n))
-				}
-			}
-			clusters[i].Metrics = metrics
-		}
-		if len(metaFreq) > 0 {
-			meta := make(map[string]json.RawMessage, len(metaFreq))
-			for k, freq := range metaFreq {
-				var topVal string
-				var topCnt int
-				for v, c := range freq {
-					if c > topCnt {
-						topVal = v
-						topCnt = c
-					}
-				}
-				if b, err := json.Marshal(topVal); err == nil {
-					meta[k] = b
-				}
-			}
-			clusters[i].Metadata = meta
-		}
-	}
-}
-
 // aggregateLeaves emits one ClusterNode per inside leaf by aggregating across
 // each leaf's id range in CH. Leaves are compressed into contiguous internal-id
 // ranges so dense full-viewport queries do not serialize giant leaf arrays into
@@ -451,7 +378,7 @@ func (sc *Supercluster) aggregateLeaves(ctx context.Context, leaves []int32) (cl
 // them projected to the target zoom (so existing clusterPoints can run).
 // Leaves are compressed into contiguous internal-id ranges to avoid serializing
 // large leaf arrays into ClickHouse query text.
-func (sc *Supercluster) fetchLeafPoints(ctx context.Context, leaves []int32, zoom int) ([]KDPoint, map[uint32]pointAttrs, error) {
+func (sc *Supercluster) fetchLeafPoints(ctx context.Context, leaves []int32, zoom int) ([]KDPoint, *attrArena, error) {
 	if len(leaves) == 0 {
 		return nil, nil, nil
 	}
@@ -462,13 +389,17 @@ func (sc *Supercluster) fetchLeafPoints(ctx context.Context, leaves []int32, zoo
 	}
 
 	out := make([]KDPoint, 0, len(leaves)*sc.Options.NodeSize)
-	attrs := make(map[uint32]pointAttrs, len(leaves)*sc.Options.NodeSize)
+	attrs := newAttrArena()
 	for start := 0; start < len(ranges); start += maxLeafIDRangesPerQuery {
 		end := start + maxLeafIDRangesPerQuery
 		if end > len(ranges) {
 			end = len(ranges)
 		}
 		where, rangeArgs := leafRangePredicate(ranges[start:end])
+		// Note: scanning the Map columns directly is faster than selecting
+		// mapKeys()/mapValues() arrays — the driver's reflection-based
+		// Array.ScanRow costs ~2x Map.ScanRow for the same data (measured at
+		// 100M: z14 avg 99ms with Map scan vs 154ms with array scan).
 		q := fmt.Sprintf(`
         SELECT id, x, y, metrics, metadata FROM clustopher.points
         WHERE cluster_id = ?
@@ -496,9 +427,7 @@ func (sc *Supercluster) fetchLeafPoints(ctx context.Context, leaves []int32, zoo
 			}
 			proj := sc.projectFast(x, y, zoom)
 			out = append(out, KDPoint{ID: id, X: proj[0], Y: proj[1], NumPoints: 1})
-			if len(metrics) > 0 || len(metadata) > 0 {
-				attrs[id] = pointAttrs{Metrics: metrics, Metadata: metadata}
-			}
+			attrs.add(id, metrics, metadata)
 		}
 		if err := rows.Err(); err != nil {
 			rows.Close()

--- a/cluster/ch_query.go
+++ b/cluster/ch_query.go
@@ -63,7 +63,7 @@ func (sc *Supercluster) queryRollup(ctx context.Context, viewport KDBounds, zoom
         GROUP BY tile_x, tile_y
     `, table)
 
-	rows, err := sc.ch.Conn().Query(ctx, q, sc.clusterID, minTX, maxTX, minTY, maxTY)
+	rows, err := sc.ch.Conn().Query(chQueryCtx(ctx, "q-rollup", nil), q, sc.clusterID, minTX, maxTX, minTY, maxTY)
 	if err != nil {
 		return nil, fmt.Errorf("query rollup: %w", err)
 	}
@@ -404,7 +404,7 @@ func (sc *Supercluster) aggregateLeaves(ctx context.Context, leaves []int32) (cl
 		args = append(args, sc.clusterID)
 		args = append(args, rangeArgs...)
 
-		rows, err := sc.ch.Conn().Query(ctx, q, args...)
+		rows, err := sc.ch.Conn().Query(chQueryCtx(ctx, "q-aggleaves", nil), q, args...)
 		if err != nil {
 			return nil, nil, fmt.Errorf("aggregate leaves: %w", err)
 		}
@@ -479,7 +479,7 @@ func (sc *Supercluster) fetchLeafPoints(ctx context.Context, leaves []int32, zoo
 		args = append(args, sc.clusterID)
 		args = append(args, rangeArgs...)
 
-		rows, err := sc.ch.Conn().Query(ctx, q, args...)
+		rows, err := sc.ch.Conn().Query(chQueryCtx(ctx, "q-leafpoints", nil), q, args...)
 		if err != nil {
 			return nil, nil, fmt.Errorf("fetch leaf points: %w", err)
 		}

--- a/cluster/ch_query.go
+++ b/cluster/ch_query.go
@@ -187,7 +187,105 @@ func (sc *Supercluster) queryTree(ctx context.Context, viewport KDBounds, zoom i
 		}
 	}
 
+	// Second-pass radius merge: aggregateLeaves emits one ClusterNode per
+	// skeleton leaf without applying the cluster radius across leaves, so at
+	// dense data the inside-leaf path can return tens of thousands of micro-
+	// clusters that should be merged into a few hundred radius-blobs. Run the
+	// same radius merge on the combined `out` so the result respects the
+	// configured Options.Radius regardless of which sub-path produced each
+	// cluster.
+	if len(out) > 1 {
+		out = sc.mergeClustersByRadius(out, zoom, float32(sc.Options.Radius))
+	}
+
 	return out, nil
+}
+
+// mergeClustersByRadius coalesces ClusterNodes whose centers fall within
+// `radius` pixels at the given query zoom. Inputs and outputs are in lng/lat.
+// Counts and metric averages are aggregated weighted by each input cluster's
+// existing Count; metadata is carried over from the first contributor in the
+// group (we don't have enough per-cluster info to majority-vote across maps
+// at this stage — `attachAttrsFromMembers` already did that for skeleton-path
+// clusters that have raw member ids).
+func (sc *Supercluster) mergeClustersByRadius(clusters []ClusterNode, zoom int, radius float32) []ClusterNode {
+	if len(clusters) <= 1 {
+		return clusters
+	}
+	type pt struct {
+		idx  int
+		x, y float32
+	}
+	pts := make([]pt, len(clusters))
+	for i, c := range clusters {
+		proj := sc.projectFast(c.X, c.Y, zoom)
+		pts[i] = pt{idx: i, x: proj[0], y: proj[1]}
+	}
+	sort.Slice(pts, func(i, j int) bool { return pts[i].x < pts[j].x })
+
+	processed := make([]bool, len(clusters))
+	out := make([]ClusterNode, 0, len(clusters))
+	r2 := radius * radius
+
+	for i := range pts {
+		srcIdx := pts[i].idx
+		if processed[srcIdx] {
+			continue
+		}
+		group := []int{srcIdx}
+		for j := i + 1; j < len(pts); j++ {
+			if pts[j].x-pts[i].x > radius {
+				break
+			}
+			if processed[pts[j].idx] {
+				continue
+			}
+			dx := pts[j].x - pts[i].x
+			dy := pts[j].y - pts[i].y
+			if dx*dx+dy*dy <= r2 {
+				group = append(group, pts[j].idx)
+			}
+		}
+		if len(group) == 1 {
+			processed[srcIdx] = true
+			out = append(out, clusters[srcIdx])
+			continue
+		}
+		var sumX, sumY float64
+		var totalCount uint32
+		metricSum := make(map[string]float64)
+		merged := ClusterNode{
+			Metrics:  make(map[string]float32),
+			Metadata: make(map[string]json.RawMessage),
+		}
+		metaSeeded := false
+		for _, gi := range group {
+			c := clusters[gi]
+			w := float64(c.Count)
+			sumX += float64(c.X) * w
+			sumY += float64(c.Y) * w
+			totalCount += c.Count
+			for k, v := range c.Metrics {
+				metricSum[k] += float64(v) * w
+			}
+			if !metaSeeded && len(c.Metadata) > 0 {
+				for k, v := range c.Metadata {
+					merged.Metadata[k] = v
+				}
+				metaSeeded = true
+			}
+			processed[gi] = true
+		}
+		merged.ID = clusters[group[0]].ID
+		merged.X = float32(sumX / float64(totalCount))
+		merged.Y = float32(sumY / float64(totalCount))
+		merged.Count = totalCount
+		for k, s := range metricSum {
+			merged.Metrics[k] = float32(s / float64(totalCount))
+		}
+		out = append(out, merged)
+	}
+	return out
 }
 
 // pointAttrs carries per-point metrics + metadata fetched from CH alongside

--- a/cluster/ch_query_attrs.go
+++ b/cluster/ch_query_attrs.go
@@ -1,0 +1,212 @@
+package cluster
+
+import "encoding/json"
+
+// attrArena is a compact, interned store for per-point metrics/metadata
+// fetched by fetchLeafPoints. Profiling the z14 city viewport at 100M showed
+// the previous map[uint32]pointAttrs representation cost ~30% of query CPU
+// and ~37 MB of allocations per query inside attachAttrsFromMembers: one
+// metrics map + one metadata map per point on the way in, and three scratch
+// maps per emitted cluster on the way out.
+//
+// The arena interns key and value strings once, stores per-point attributes
+// as contiguous {keyID, val} entries, and lets the aggregation loop run over
+// dense slices with no per-cluster map allocations.
+type attrArena struct {
+	metricKeys []string
+	metricIdx  map[string]uint16
+
+	metaKeys    []string
+	metaIdx     map[string]uint16
+	metaVals    [][]string            // per meta key: valID -> value
+	metaValIdx  []map[string]uint32   // per meta key: value -> valID
+	metaValJSON [][]json.RawMessage   // per meta key: valID -> memoized JSON
+
+	metricKV []metricKV
+	metaKV   []metaKV
+	spans    map[uint32]attrSpan // point id -> entry ranges
+}
+
+type metricKV struct {
+	key uint16
+	val float32
+}
+
+type metaKV struct {
+	key uint16
+	val uint32
+}
+
+type attrSpan struct {
+	mOff, dOff uint32
+	mLen, dLen uint16
+}
+
+func newAttrArena() *attrArena {
+	return &attrArena{
+		metricIdx: make(map[string]uint16),
+		metaIdx:   make(map[string]uint16),
+		spans:     make(map[uint32]attrSpan),
+	}
+}
+
+func (a *attrArena) metricKey(k string) uint16 {
+	if id, ok := a.metricIdx[k]; ok {
+		return id
+	}
+	id := uint16(len(a.metricKeys))
+	a.metricKeys = append(a.metricKeys, k)
+	a.metricIdx[k] = id
+	return id
+}
+
+func (a *attrArena) metaKey(k string) uint16 {
+	if id, ok := a.metaIdx[k]; ok {
+		return id
+	}
+	id := uint16(len(a.metaKeys))
+	a.metaKeys = append(a.metaKeys, k)
+	a.metaIdx[k] = id
+	a.metaVals = append(a.metaVals, nil)
+	a.metaValIdx = append(a.metaValIdx, make(map[string]uint32))
+	a.metaValJSON = append(a.metaValJSON, nil)
+	return id
+}
+
+func (a *attrArena) metaVal(key uint16, v string) uint32 {
+	if id, ok := a.metaValIdx[key][v]; ok {
+		return id
+	}
+	id := uint32(len(a.metaVals[key]))
+	a.metaVals[key] = append(a.metaVals[key], v)
+	a.metaValIdx[key][v] = id
+	a.metaValJSON[key] = append(a.metaValJSON[key], nil)
+	return id
+}
+
+// valJSON returns the JSON encoding of a meta value, memoized — metadata
+// values repeat across thousands of clusters per query.
+func (a *attrArena) valJSON(key uint16, val uint32) json.RawMessage {
+	if a.metaValJSON[key][val] == nil {
+		if b, err := json.Marshal(a.metaVals[key][val]); err == nil {
+			a.metaValJSON[key][val] = b
+		}
+	}
+	return a.metaValJSON[key][val]
+}
+
+// add records one point's attributes. The input maps are copied into the
+// arena; callers may reuse or discard them.
+func (a *attrArena) add(id uint32, metrics map[string]float32, metadata map[string]string) {
+	if len(metrics) == 0 && len(metadata) == 0 {
+		return
+	}
+	sp := attrSpan{mOff: uint32(len(a.metricKV)), dOff: uint32(len(a.metaKV))}
+	for k, v := range metrics {
+		a.metricKV = append(a.metricKV, metricKV{key: a.metricKey(k), val: v})
+	}
+	for k, v := range metadata {
+		ki := a.metaKey(k)
+		a.metaKV = append(a.metaKV, metaKV{key: ki, val: a.metaVal(ki, v)})
+	}
+	sp.mLen = uint16(uint32(len(a.metricKV)) - sp.mOff)
+	sp.dLen = uint16(uint32(len(a.metaKV)) - sp.dOff)
+	a.spans[id] = sp
+}
+
+// attachAttrsFromMembers fills each cluster's Metrics/Metadata by aggregating
+// the per-member attributes recorded in the arena. Metrics are averaged so the
+// per-cluster value matches the convention used by the rollup and
+// aggregateLeaves paths (sum/cnt); metadata picks the most common value per
+// key across members (ties resolved by first value to reach the top count).
+// Clusters whose Children list is empty are left untouched.
+//
+// Scratch state is allocated once per call and reset between clusters via
+// touched-entry lists, so per-cluster work allocates only the two small output
+// maps actually attached to the ClusterNode.
+func attachAttrsFromMembers(clusters []ClusterNode, attrs *attrArena) {
+	if attrs == nil || len(attrs.spans) == 0 {
+		return
+	}
+	nm := len(attrs.metricKeys)
+	nd := len(attrs.metaKeys)
+
+	sums := make([]float64, nm)
+	counts := make([]uint64, nm)
+	touchedM := make([]uint16, 0, nm)
+
+	freq := make([][]int32, nd)
+	for k := range freq {
+		freq[k] = make([]int32, len(attrs.metaVals[k]))
+	}
+	touchedD := make([]metaKV, 0, 64)
+	top := make([]uint32, nd)
+	topCnt := make([]int32, nd)
+	keyTouched := make([]bool, nd)
+	touchedKeys := make([]uint16, 0, nd)
+
+	for i := range clusters {
+		members := clusters[i].Children
+		if len(members) == 0 {
+			continue
+		}
+		for _, k := range touchedM {
+			sums[k] = 0
+			counts[k] = 0
+		}
+		touchedM = touchedM[:0]
+		for _, kv := range touchedD {
+			freq[kv.key][kv.val] = 0
+		}
+		touchedD = touchedD[:0]
+		for _, k := range touchedKeys {
+			keyTouched[k] = false
+			topCnt[k] = 0
+		}
+		touchedKeys = touchedKeys[:0]
+
+		for _, id := range members {
+			sp, ok := attrs.spans[id]
+			if !ok {
+				continue
+			}
+			for _, kv := range attrs.metricKV[sp.mOff : sp.mOff+uint32(sp.mLen)] {
+				if counts[kv.key] == 0 {
+					touchedM = append(touchedM, kv.key)
+				}
+				sums[kv.key] += float64(kv.val)
+				counts[kv.key]++
+			}
+			for _, kv := range attrs.metaKV[sp.dOff : sp.dOff+uint32(sp.dLen)] {
+				if freq[kv.key][kv.val] == 0 {
+					touchedD = append(touchedD, kv)
+				}
+				if !keyTouched[kv.key] {
+					keyTouched[kv.key] = true
+					touchedKeys = append(touchedKeys, kv.key)
+				}
+				f := freq[kv.key][kv.val] + 1
+				freq[kv.key][kv.val] = f
+				if f > topCnt[kv.key] {
+					topCnt[kv.key] = f
+					top[kv.key] = kv.val
+				}
+			}
+		}
+
+		if len(touchedM) > 0 {
+			metrics := make(map[string]float32, len(touchedM))
+			for _, k := range touchedM {
+				metrics[attrs.metricKeys[k]] = float32(sums[k] / float64(counts[k]))
+			}
+			clusters[i].Metrics = metrics
+		}
+		if len(touchedKeys) > 0 {
+			meta := make(map[string]json.RawMessage, len(touchedKeys))
+			for _, k := range touchedKeys {
+				meta[attrs.metaKeys[k]] = attrs.valJSON(k, top[k])
+			}
+			clusters[i].Metadata = meta
+		}
+	}
+}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -121,6 +121,17 @@ const (
 	// Changing this requires recreating all rollup_z* tables and their MVs;
 	// MVs are not auto-updated when this constant changes.
 	DefaultRollupRadius = 40
+
+	// MinRollupZoom / MaxRollupZoom bracket the zoom levels for which a rollup
+	// materialized view is created. Queries with `zoom < ZSplit` (default 11)
+	// hit these MVs; zooms >= ZSplit walk the skeleton tree instead. Creating
+	// MVs for zooms that are never queried via the rollup path is pure
+	// write-amplification cost during bulk Load (each MV multiplies the per-
+	// row insert cost), so we cap MaxRollupZoom one below the default ZSplit.
+	// If you raise ZSplit, raise MaxRollupZoom to match and rebuild the rollup
+	// tables.
+	MinRollupZoom = 2
+	MaxRollupZoom = 10
 )
 
 // NewSupercluster creates a new clustering instance
@@ -561,12 +572,16 @@ func (sc *Supercluster) createCluster(points []KDPoint) ClusterNode {
 		}
 	}
 
-	// Create cluster node
+	// Create cluster node. Children retains the member ids so the partial-leaf
+	// path in queryTree can reattach per-point metrics/metadata fetched
+	// alongside the geometry — the rollup MV and aggregateLeaves paths set
+	// metrics directly from SQL and leave Children empty.
 	cluster := ClusterNode{
 		ID:       points[0].ID, // Now this is safe because we've checked len(points) > 0
 		X:        float32(sumX / float64(totalPoints)),
 		Y:        float32(sumY / float64(totalPoints)),
 		Count:    totalPoints,
+		Children: pointIDs,
 		Metrics:  make(map[string]float32),
 		Metadata: make(map[string]json.RawMessage),
 	}
@@ -577,10 +592,11 @@ func (sc *Supercluster) createCluster(points []KDPoint) ClusterNode {
 // createSinglePointCluster creates a cluster for a single point
 func (sc *Supercluster) createSinglePointCluster(p KDPoint) ClusterNode {
 	return ClusterNode{
-		ID:    p.ID,
-		X:     p.X,
-		Y:     p.Y,
-		Count: 1,
+		ID:       p.ID,
+		X:        p.X,
+		Y:        p.Y,
+		Count:    1,
+		Children: []uint32{p.ID},
 	}
 }
 

--- a/cluster/metric_rollup_test.go
+++ b/cluster/metric_rollup_test.go
@@ -1,0 +1,355 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// metricSpec describes how a single metric key is generated per-point and
+// what its dataset-wide sum should be, given n points.
+//
+// CHExpr is a ClickHouse expression evaluated in the SELECT used to build the
+// staging table. It can reference `number` (the row's 0-based index) and must
+// produce a Float32. ExpectedSum returns the exact ground-truth sum across
+// all n points in float64.
+type metricSpec struct {
+	CHExpr      string
+	ExpectedSum func(n int) float64
+}
+
+// TestMetricRollupAllZooms stages a deterministic dataset where each metric
+// key has a known per-point formula and a closed-form total. The test then:
+//
+//  1. probes clustopher.staging_points to sanity-check the staged dataset,
+//  2. loads via LoadFromCHStreaming so the rollup MVs fire on insert,
+//  3. probes each rollup_z{N} table directly to confirm SummingMergeTree is
+//     actually summing the Map columns (catches the SimpleAggregateFunction
+//     bug in the rollup schema),
+//  4. for each zoom 2..16, queries GetClustersCH with a world viewport so all
+//     points must be returned, and asserts Σ Count == n and the per-metric
+//     reconstructed Σ Count*mean matches the expected sum within eps. This
+//     catches both the rollup-merge bug (low/mid zoom) and the
+//     partial-leaf-path metric-drop bug (high zoom).
+//
+// Gated by CLUSTOPHER_METRIC_ROLLUP=1; needs a live ClickHouse. Env:
+//
+//	CLICKHOUSE_DSN              standard CH DSN (required)
+//	CLUSTOPHER_METRIC_ROLLUP    must be "1" to enable
+//	CLUSTOPHER_METRIC_ROLLUP_N  optional point count override (default 50000)
+//	                            must be a multiple of seqMod (100) so the
+//	                            varying-metric expected sum stays exact.
+func TestMetricRollupAllZooms(t *testing.T) {
+	if os.Getenv("CLUSTOPHER_METRIC_ROLLUP") != "1" {
+		t.Skip("set CLUSTOPHER_METRIC_ROLLUP=1 to run metric rollup verification")
+	}
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+
+	n := 50_000
+	if v := os.Getenv("CLUSTOPHER_METRIC_ROLLUP_N"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed < 1 {
+			t.Fatalf("invalid CLUSTOPHER_METRIC_ROLLUP_N=%q", v)
+		}
+		n = parsed
+	}
+
+	const seqMod = 100
+	if n%seqMod != 0 {
+		t.Fatalf("n=%d must be a multiple of seqMod=%d", n, seqMod)
+	}
+
+	// Generation box well away from Mercator poles.
+	genBBox := KDBounds{MinX: -100, MinY: 35, MaxX: -90, MaxY: 45}
+	// World viewport stays clear of ±90 (latToY -> ±∞) but covers every
+	// generated point at every zoom.
+	worldVP := KDBounds{MinX: -180, MinY: -85, MaxX: 180, MaxY: 85}
+
+	specs := map[string]metricSpec{
+		// Constant per-point sanity metric.
+		"value_const_1": {
+			CHExpr:      "toFloat32(1)",
+			ExpectedSum: func(n int) float64 { return float64(n) },
+		},
+		// Distinct constant — value differs from value_const_1 so a
+		// "always returns 1" implementation can't sneak through.
+		"value_const_7": {
+			CHExpr:      "toFloat32(7)",
+			ExpectedSum: func(n int) float64 { return float64(n) * 7 },
+		},
+		// Varying metric: (number mod 100) + 1, so each integer 1..100
+		// appears exactly n/seqMod times. Catches the SummingMergeTree
+		// Map-merge bug, which only manifests when per-point values
+		// differ (mean of a single sample row ≠ mean of all rows).
+		"value_seq_mod": {
+			CHExpr:      "toFloat32((number % 100) + 1)",
+			ExpectedSum: func(n int) float64 { return float64(n) / float64(seqMod) * float64(seqMod*(seqMod+1)/2) },
+		},
+	}
+
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	clusterID := fmt.Sprintf("METRIC_ROLLUP_%d", n)
+	cleanup := func() {
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+		for z := 2; z <= 16; z++ {
+			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
+		}
+	}
+	cleanup()
+	defer cleanup()
+
+	if err := generateMetricPoints(ctx, c, clusterID, n, genBBox, specs); err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+
+	keys := make([]string, 0, len(specs))
+	for k := range specs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	expectedSums := make(map[string]float64, len(specs))
+	for _, k := range keys {
+		expectedSums[k] = specs[k].ExpectedSum(n)
+	}
+
+	// Sanity-check the staging row before loading.
+	if err := assertCHSums(ctx, c, "staging_points sanity",
+		"SELECT count(), sumMap(metrics) FROM clustopher.staging_points WHERE cluster_id = ?",
+		clusterID, uint64(n), expectedSums, 0, t); err != nil {
+		t.Fatalf("staging sanity: %v", err)
+	}
+
+	sc := NewSupercluster(SuperclusterOptions{
+		MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40, Extent: 512, NodeSize: 64,
+	})
+	sc.SetCHClient(c)
+	sc.SetClusterID(clusterID)
+
+	start := time.Now()
+	if err := sc.LoadFromCHStreaming(ctx); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	t.Logf("loaded n=%d in %.2fs leaves=%d", n, time.Since(start).Seconds(), len(sc.Skeleton.Leaves))
+
+	// Force rollup MV merges so per-tile rows are fully merged.
+	for z := 2; z <= 16; z++ {
+		_ = c.Conn().Exec(ctx, "OPTIMIZE TABLE clustopher.rollup_z"+strconv.Itoa(z)+" PARTITION ? FINAL", clusterID)
+	}
+
+	// 1) Verify the canonical points table received the right data.
+	if err := assertCHSums(ctx, c, "clustopher.points",
+		"SELECT count(), sumMap(metrics) FROM clustopher.points WHERE cluster_id = ?",
+		clusterID, uint64(n), expectedSums, 0, t); err != nil {
+		t.Errorf("points sanity: %v", err)
+	}
+
+	// 2) Direct rollup-table probe: catches SummingMergeTree map-merge bug
+	// independent of the Go query path.
+	for z := 2; z <= 16; z++ {
+		label := fmt.Sprintf("rollup_z%02d", z)
+		q := fmt.Sprintf(
+			"SELECT sum(cnt), sumMap(metric_sums) FROM clustopher.rollup_z%d WHERE cluster_id = ?", z)
+		if err := assertCHSums(ctx, c, label, q, clusterID, uint64(n), expectedSums, 1e-9, t); err != nil {
+			t.Errorf("%s: %v", label, err)
+		}
+		// Also verify metric_cnts sums to n per key — SummingMergeTree
+		// must sum it too.
+		row := c.Conn().QueryRow(ctx,
+			"SELECT sumMap(metric_cnts) FROM clustopher.rollup_z"+strconv.Itoa(z)+" WHERE cluster_id = ?", clusterID)
+		var cntsMap map[string]uint64
+		if err := row.Scan(&cntsMap); err != nil {
+			t.Errorf("%s metric_cnts scan: %v", label, err)
+			continue
+		}
+		for _, k := range keys {
+			if cntsMap[k] != uint64(n) {
+				t.Errorf("%s metric_cnts[%s] = %d, want %d", label, k, cntsMap[k], n)
+			}
+		}
+	}
+
+	// 3) Go-level: GetClustersCH per zoom with world viewport. Σ Count must
+	// equal n; Σ Count*mean must equal expected sum within eps.
+	const relEps = 1e-4
+
+	var anyFail bool
+	for z := 2; z <= 16; z++ {
+		qStart := time.Now()
+		clusters, err := sc.GetClustersCH(ctx, worldVP, z)
+		if err != nil {
+			t.Errorf("z=%d GetClustersCH: %v", z, err)
+			anyFail = true
+			continue
+		}
+
+		var totalCount uint64
+		observedSums := make(map[string]float64, len(specs))
+		for _, cl := range clusters {
+			totalCount += uint64(cl.Count)
+			for _, k := range keys {
+				observedSums[k] += float64(cl.Count) * float64(cl.Metrics[k])
+			}
+		}
+
+		var sumStr strings.Builder
+		for i, k := range keys {
+			if i > 0 {
+				sumStr.WriteString(" ")
+			}
+			fmt.Fprintf(&sumStr, "%s=%.1f/%.1f", k, observedSums[k], expectedSums[k])
+		}
+		path := "rollup"
+		if z >= sc.Options.ZSplit {
+			path = "skel"
+		}
+		t.Logf("z=%02d path=%-6s clusters=%6d count=%d/%d %s elapsed=%.1fms",
+			z, path, len(clusters), totalCount, uint64(n), sumStr.String(),
+			float64(time.Since(qStart).Microseconds())/1000.0)
+
+		if totalCount != uint64(n) {
+			t.Errorf("z=%d count mismatch: observed=%d expected=%d", z, totalCount, n)
+			anyFail = true
+		}
+		for _, k := range keys {
+			exp := expectedSums[k]
+			obs := observedSums[k]
+			denom := math.Abs(exp)
+			if denom == 0 {
+				denom = 1
+			}
+			rel := math.Abs(obs-exp) / denom
+			if rel > relEps {
+				t.Errorf("z=%d metric %s sum mismatch: observed=%.6f expected=%.6f rel=%.2e",
+					z, k, obs, exp, rel)
+				anyFail = true
+			}
+		}
+	}
+	if anyFail {
+		t.Fatal("metric rollup verification failed")
+	}
+}
+
+// assertCHSums runs a single query returning (count, sumMap(metrics)) for the
+// supplied clusterID and checks the row against expectedCount + expectedSums.
+// relEps > 0 enables float-relative comparison; 0 forces exact uint match.
+func assertCHSums(
+	ctx context.Context,
+	c *CHClient,
+	label string,
+	query string,
+	clusterID string,
+	expectedCount uint64,
+	expectedSums map[string]float64,
+	relEps float64,
+	t *testing.T,
+) error {
+	row := c.Conn().QueryRow(ctx, query, clusterID)
+	var (
+		cnt  uint64
+		sums map[string]float64
+	)
+	if err := row.Scan(&cnt, &sums); err != nil {
+		return fmt.Errorf("%s scan: %w", label, err)
+	}
+	t.Logf("%s cnt=%d sums=%v", label, cnt, sums)
+	if cnt != expectedCount {
+		return fmt.Errorf("%s cnt=%d, want %d", label, cnt, expectedCount)
+	}
+	keys := make([]string, 0, len(expectedSums))
+	for k := range expectedSums {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		exp := expectedSums[k]
+		got := sums[k]
+		if relEps == 0 {
+			if got != exp {
+				return fmt.Errorf("%s sum[%s]=%g, want %g", label, k, got, exp)
+			}
+			continue
+		}
+		denom := math.Abs(exp)
+		if denom == 0 {
+			denom = 1
+		}
+		if math.Abs(got-exp)/denom > relEps {
+			return fmt.Errorf("%s sum[%s]=%g, want %g (rel=%.2e)",
+				label, k, got, exp, math.Abs(got-exp)/denom)
+		}
+	}
+	return nil
+}
+
+// generateMetricPoints stages n points with deterministic cityHash64-driven
+// coordinates inside bbox. Each metric in specs is generated per-point via its
+// CHExpr (a ClickHouse expression over `number`), so callers can encode both
+// constant-per-point metrics and varying ones — and the closed-form
+// ExpectedSum lets the test compute ground truth in-Go.
+func generateMetricPoints(ctx context.Context, c *CHClient, clusterID string, n int, bbox KDBounds, specs map[string]metricSpec) error {
+	if n < 1 {
+		return fmt.Errorf("generateMetricPoints requires n>=1, got %d", n)
+	}
+	if len(specs) == 0 {
+		return fmt.Errorf("generateMetricPoints requires at least one metric")
+	}
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(insertSettings))
+
+	keys := make([]string, 0, len(specs))
+	for k := range specs {
+		if strings.ContainsAny(k, "'\\") {
+			return fmt.Errorf("metric key %q contains disallowed character", k)
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys)*2)
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("'%s'", k))
+		parts = append(parts, specs[k].CHExpr)
+	}
+	metricsExpr := "map(" + strings.Join(parts, ", ") + ")"
+
+	query := fmt.Sprintf(`
+        INSERT INTO clustopher.staging_points (cluster_id, external_id, x, y, metrics, metadata)
+        SELECT
+            ? AS cluster_id,
+            toUInt32(number + 1) AS external_id,
+            toFloat32(? + (cityHash64(number, 1) / 18446744073709551615.0) * (? - ?)) AS x,
+            toFloat32(? + (cityHash64(number, 2) / 18446744073709551615.0) * (? - ?)) AS y,
+            %s AS metrics,
+            map('type', 'metric_rollup_test') AS metadata
+        FROM numbers(?)
+    `, metricsExpr)
+
+	return c.Conn().Exec(ctx, query,
+		clusterID,
+		bbox.MinX, bbox.MaxX, bbox.MinX,
+		bbox.MinY, bbox.MaxY, bbox.MinY,
+		uint64(n),
+	)
+}

--- a/cluster/metric_rollup_test.go
+++ b/cluster/metric_rollup_test.go
@@ -112,7 +112,7 @@ func TestMetricRollupAllZooms(t *testing.T) {
 	cleanup := func() {
 		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
 		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
-		for z := 2; z <= 16; z++ {
+		for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
 			_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.rollup_z"+strconv.Itoa(z)+" DROP PARTITION ?", clusterID)
 		}
 	}
@@ -153,8 +153,10 @@ func TestMetricRollupAllZooms(t *testing.T) {
 	}
 	t.Logf("loaded n=%d in %.2fs leaves=%d", n, time.Since(start).Seconds(), len(sc.Skeleton.Leaves))
 
-	// Force rollup MV merges so per-tile rows are fully merged.
-	for z := 2; z <= 16; z++ {
+	// Force rollup MV merges so per-tile rows are fully merged. Only zooms
+	// [MinRollupZoom..MaxRollupZoom] have MV tables; higher zooms answer via
+	// the skeleton path and have no rollup to verify directly.
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
 		_ = c.Conn().Exec(ctx, "OPTIMIZE TABLE clustopher.rollup_z"+strconv.Itoa(z)+" PARTITION ? FINAL", clusterID)
 	}
 
@@ -166,8 +168,9 @@ func TestMetricRollupAllZooms(t *testing.T) {
 	}
 
 	// 2) Direct rollup-table probe: catches SummingMergeTree map-merge bug
-	// independent of the Go query path.
-	for z := 2; z <= 16; z++ {
+	// independent of the Go query path. Limited to the zooms that actually
+	// have rollup MV tables; high zooms (>= ZSplit) are validated via path 3.
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
 		label := fmt.Sprintf("rollup_z%02d", z)
 		q := fmt.Sprintf(
 			"SELECT sum(cnt), sumMap(metric_sums) FROM clustopher.rollup_z%d WHERE cluster_id = ?", z)

--- a/cluster/migrations.go
+++ b/cluster/migrations.go
@@ -59,8 +59,8 @@ func RunMigrations(ctx context.Context, conn driver.Conn, dir string) error {
 
 func expandPerZoom(template string) []string {
 	radius := fmt.Sprintf("%d", DefaultRollupRadius)
-	out := make([]string, 0, 15)
-	for z := 2; z <= 16; z++ {
+	out := make([]string, 0, MaxRollupZoom-MinRollupZoom+1)
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
 		s := strings.ReplaceAll(template, "{N}", fmt.Sprintf("%d", z))
 		s = strings.ReplaceAll(s, "{RADIUS}", radius)
 		out = append(out, s)

--- a/cluster/migrations/002_rollup_template.sql
+++ b/cluster/migrations/002_rollup_template.sql
@@ -2,6 +2,11 @@
 -- cluster.DefaultRollupRadius. Recreate all MVs if DefaultRollupRadius changes
 -- — the value is baked into stored tile coords.
 
+-- metric_sums / metric_cnts must be SimpleAggregateFunction(sumMap, ...) so
+-- SummingMergeTree merges them by summing values across matching keys.
+-- Plain Map columns are NOT auto-summed by SummingMT — rows with identical
+-- sort keys keep only one row's map after merge, so per-tile metric totals
+-- silently become "one point's worth" instead of "all points in tile".
 CREATE TABLE IF NOT EXISTS clustopher.rollup_z{N} (
     cluster_id  String,
     tile_x      UInt32,
@@ -9,8 +14,8 @@ CREATE TABLE IF NOT EXISTS clustopher.rollup_z{N} (
     cnt         UInt64,
     sum_x       Float64,
     sum_y       Float64,
-    metric_sums Map(String, Float64),
-    metric_cnts Map(String, UInt64)
+    metric_sums SimpleAggregateFunction(sumMap, Map(String, Float64)),
+    metric_cnts SimpleAggregateFunction(sumMap, Map(String, UInt64))
 ) ENGINE = SummingMergeTree
 PARTITION BY cluster_id
 ORDER BY (cluster_id, tile_x, tile_y);

--- a/cluster/migrations_test.go
+++ b/cluster/migrations_test.go
@@ -50,7 +50,7 @@ func TestRunMigrations_CreatesTables(t *testing.T) {
 		}
 	}
 
-	for z := 2; z <= 16; z++ {
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
 		var c uint64
 		q := "SELECT count() FROM system.tables WHERE database='clustopher' AND name=?"
 		row := conn.QueryRow(context.Background(), q, "rollup_z"+strconv.Itoa(z))
@@ -62,7 +62,7 @@ func TestRunMigrations_CreatesTables(t *testing.T) {
 		}
 	}
 
-	for z := 2; z <= 16; z++ {
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
 		var c uint64
 		q := "SELECT count() FROM system.tables WHERE database='clustopher' AND name=?"
 		if err := conn.QueryRow(context.Background(), q, "mv_rollup_z"+strconv.Itoa(z)).Scan(&c); err != nil {

--- a/cluster/seed_nyc_15m_test.go
+++ b/cluster/seed_nyc_15m_test.go
@@ -1,0 +1,80 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestSeedNYC15M seeds a 15M-point cluster confined to NYC bounds using the
+// Morton streaming load path. Gated by SEED_NYC_15M=1.
+//
+//	SEED_NYC_15M=1 CLUSTOPHER_CLUSTER_ID=NYC_15M \
+//	  CLICKHOUSE_DSN=clickhouse://default:@127.0.0.1:19000/clustopher \
+//	  go test ./cluster -run TestSeedNYC15M -v -timeout 1h
+func TestSeedNYC15M(t *testing.T) {
+	if os.Getenv("SEED_NYC_15M") != "1" {
+		t.Skip("set SEED_NYC_15M=1 to seed a 15M NYC cluster")
+	}
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+
+	clusterID := os.Getenv("CLUSTOPHER_CLUSTER_ID")
+	if clusterID == "" {
+		clusterID = "NYC_15M"
+	}
+
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	// NYC bounding box.
+	nyc := KDBounds{MinX: -74.2591, MinY: 40.4774, MaxX: -73.7004, MaxY: 40.9176}
+
+	// Clean any prior partition with this id.
+	_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+	_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", clusterID)
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+		_ = c.Conn().Exec(ctx, fmt.Sprintf("ALTER TABLE clustopher.rollup_z%d DROP PARTITION ?", z), clusterID)
+	}
+
+	const n = 15_000_000
+	start := time.Now()
+	if err := generateDenseStagingPoints(ctx, c, clusterID, n, nyc); err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+	t.Logf("staged %d NYC points in %.1fs", n, time.Since(start).Seconds())
+
+	sc := NewSupercluster(SuperclusterOptions{
+		MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40, Extent: 512, NodeSize: 64,
+	})
+	sc.SetCHClient(c)
+	sc.SetClusterID(clusterID)
+
+	start = time.Now()
+	if err := sc.LoadFromCHStreaming(ctx); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	t.Logf("loaded NYC cluster id=%s in %.1fs leaves=%d", clusterID, time.Since(start).Seconds(), len(sc.Skeleton.Leaves))
+
+	start = time.Now()
+	for z := MinRollupZoom; z <= MaxRollupZoom; z++ {
+		_ = c.Conn().Exec(ctx, fmt.Sprintf("OPTIMIZE TABLE clustopher.rollup_z%d PARTITION ? FINAL", z), clusterID)
+	}
+	t.Logf("optimized rollups in %.1fs", time.Since(start).Seconds())
+
+	// Drop staging — canonical points are now populated.
+	_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", clusterID)
+
+	t.Logf("DONE. Cluster '%s' ready: 15M points across NYC (%v).", clusterID, nyc)
+}

--- a/cluster/skeleton.go
+++ b/cluster/skeleton.go
@@ -65,8 +65,27 @@ func BuildSkeleton(points []KDPoint, nodeSize int) *SkeletonTree {
 		tree.Leaves = append(tree.Leaves, leaf)
 	}
 
-	// 2. Build internal nodes bottom-up. Each leaf becomes a SkeletonNode with
-	//    LeafIdx set; we then pair them into a balanced binary tree.
+	buildInternalNodes(tree)
+	return tree
+}
+
+// BuildSkeletonFromLeaves takes an already-emitted []SkeletonLeaf (e.g. built
+// from a streaming sort) and lays out the SkeletonNode array (leaves first,
+// then the bottom-up balanced binary internal tree). Equivalent to calling
+// BuildSkeleton on the underlying points except no points are materialized.
+func BuildSkeletonFromLeaves(leaves []SkeletonLeaf) *SkeletonTree {
+	tree := &SkeletonTree{Leaves: leaves}
+	if len(leaves) == 0 {
+		return tree
+	}
+	buildInternalNodes(tree)
+	return tree
+}
+
+// buildInternalNodes assumes tree.Leaves is populated and tree.Nodes is empty.
+// It appends one SkeletonNode per leaf, then pairs them bottom-up into a
+// balanced binary tree.
+func buildInternalNodes(tree *SkeletonTree) {
 	type lvl struct{ idx int32 }
 	current := make([]lvl, len(tree.Leaves))
 	for i, lf := range tree.Leaves {
@@ -98,7 +117,6 @@ func BuildSkeleton(points []KDPoint, nodeSize int) *SkeletonTree {
 		axis ^= 1
 		current = next
 	}
-	return tree
 }
 
 func boundsOver(pts []KDPoint) KDBounds {

--- a/cluster/z14_query_profile_test.go
+++ b/cluster/z14_query_profile_test.go
@@ -1,0 +1,110 @@
+package cluster
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestZ14QueryProfile drives GetClustersCH at z14 against a persistent 100M
+// cluster for Go-side CPU/heap profiling. The cluster is staged + loaded on
+// the first run and reused afterwards (partition QPROF_<N> is intentionally
+// NOT dropped), so a second run profiles queries, not the load.
+//
+//	CLUSTOPHER_QPROF=1 CLICKHOUSE_DSN=... go test ./cluster -run TestZ14QueryProfile -v \
+//	  -cpuprofile=../benchmark_results/z14_cpu.pprof -memprofile=../benchmark_results/z14_mem.pprof
+func TestZ14QueryProfile(t *testing.T) {
+	if os.Getenv("CLUSTOPHER_QPROF") != "1" {
+		t.Skip("set CLUSTOPHER_QPROF=1")
+	}
+	dsn := os.Getenv("CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+
+	n := 100_000_000
+	if v := os.Getenv("CLUSTOPHER_QPROF_N"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed < 1 {
+			t.Fatalf("invalid CLUSTOPHER_QPROF_N=%q", v)
+		}
+		n = parsed
+	}
+	iters := 20
+	if v := os.Getenv("CLUSTOPHER_QPROF_ITERS"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed < 1 {
+			t.Fatalf("invalid CLUSTOPHER_QPROF_ITERS=%q", v)
+		}
+		iters = parsed
+	}
+
+	conus := KDBounds{MinX: -125, MinY: 25, MaxX: -65, MaxY: 49}
+	city := KDBounds{MinX: -100.25, MinY: 39.25, MaxX: -99.75, MaxY: 39.75}
+
+	ctx := context.Background()
+	c, err := NewCHClient(ctx, CHConfig{DSN: dsn})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+	if err := RunMigrations(ctx, c.Conn(), "migrations"); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	cid := "QPROF_" + strconv.Itoa(n)
+	sc := NewSupercluster(SuperclusterOptions{
+		MinZoom: 0, MaxZoom: 16, MinPoints: 3, Radius: 40, Extent: 512, NodeSize: 64,
+	})
+	sc.SetCHClient(c)
+	sc.SetClusterID(cid)
+
+	var have uint64
+	if err := c.Conn().QueryRow(ctx,
+		"SELECT count() FROM clustopher.points WHERE cluster_id = ?", cid).Scan(&have); err != nil {
+		t.Fatalf("count existing: %v", err)
+	}
+	if have == uint64(n) {
+		t.Logf("reusing existing partition %s", cid)
+		start := time.Now()
+		leaves, err := sc.readLeafBoundsFromPoints(ctx)
+		if err != nil {
+			t.Fatalf("leaf bounds: %v", err)
+		}
+		sc.Skeleton = BuildSkeletonFromLeaves(leaves)
+		t.Logf("skeleton rebuilt in %s (%d leaves)", time.Since(start).Round(time.Millisecond), len(leaves))
+	} else {
+		t.Logf("staging %d points (existing=%d)", n, have)
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.points DROP PARTITION ?", cid)
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", cid)
+		if err := generateDenseStagingPoints(ctx, c, cid, n, conus); err != nil {
+			t.Fatalf("stage: %v", err)
+		}
+		start := time.Now()
+		if err := sc.LoadFromCHSinglePass(ctx); err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		t.Logf("loaded in %s", time.Since(start).Round(time.Second))
+		_ = c.Conn().Exec(ctx, "ALTER TABLE clustopher.staging_points DROP PARTITION ?", cid)
+	}
+
+	// Warmup, then timed loop — this is the pprof target.
+	for i := 0; i < 2; i++ {
+		if _, err := sc.GetClustersCH(ctx, city, 14); err != nil {
+			t.Fatalf("warmup query: %v", err)
+		}
+	}
+	start := time.Now()
+	var clusters []ClusterNode
+	for i := 0; i < iters; i++ {
+		clusters, err = sc.GetClustersCH(ctx, city, 14)
+		if err != nil {
+			t.Fatalf("query %d: %v", i, err)
+		}
+	}
+	elapsed := time.Since(start)
+	t.Logf("z14 city viewport: %d iters, avg %s, clusters=%d",
+		iters, (elapsed / time.Duration(iters)).Round(time.Microsecond), len(clusters))
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -60,8 +60,16 @@ func main() {
 	apiPort := flag.String("port", "8000", "HTTP API listen port")
 	flag.Parse()
 
-	// Connect to cluster runner
-	conn, err := grpc.Dial(*runnersAddr, grpc.WithInsecure())
+	// Connect to cluster runner. Match the runner's 256 MB cap so high-zoom
+	// skeleton-path responses (Children-bearing ClusterNodes) round-trip OK.
+	const maxMsg = 256 * 1024 * 1024
+	conn, err := grpc.Dial(*runnersAddr,
+		grpc.WithInsecure(),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxMsg),
+			grpc.MaxCallSendMsgSize(maxMsg),
+		),
+	)
 	if err != nil {
 		fmt.Printf("Failed to connect to cluster runner: %v\n", err)
 		os.Exit(1)

--- a/cmd/runners/main.go
+++ b/cmd/runners/main.go
@@ -44,7 +44,14 @@ func main() {
 		log.Fatalf("listen: %v", err)
 	}
 
-	s := grpc.NewServer()
+	// Raise default 4 MB message cap — at high zoom skeleton-path responses
+	// can return tens of thousands of clusters with Children member-id slices,
+	// well past 4 MB.
+	const maxMsg = 256 * 1024 * 1024
+	s := grpc.NewServer(
+		grpc.MaxRecvMsgSize(maxMsg),
+		grpc.MaxSendMsgSize(maxMsg),
+	)
 	clusterRunner := runner.NewClusterRunner(*maxClusters, ch)
 	proto.RegisterClusterServiceServer(s, clusterRunner)
 	reflection.Register(s)

--- a/docs/superpowers/specs/2026-06-04-ch-load-query-optimization-design.md
+++ b/docs/superpowers/specs/2026-06-04-ch-load-query-optimization-design.md
@@ -1,0 +1,82 @@
+# CH Load + Query Optimization — Design
+
+**Date:** 2026-06-04
+**Branch:** tc/ch-streaming-load
+**Status:** Approved
+
+## Goal
+
+Evidence-driven optimization of two tracks, profiled at 100M points (scales
+linearly so far), final verification at 3B:
+
+1. **Load track** — single-pass load (`LoadFromCHSinglePass`): at 3B the
+   morton+rowNumber INSERT is 58 min (83%) and the rollup batch populate is
+   10.7 min (15%) of a 69.6 min load.
+2. **Query track** — z14 city-viewport query: 3984 ms / 993 MB alloc per op
+   at 3B (z2 = 3.4 ms, z8 = 17.5 ms are fine).
+
+Success bar: profile first, fix what the profiles say, keep every win that
+does not break the 3B memory ceiling. No fixed numeric targets. Final 3B
+re-verify run at the end.
+
+## Instrumentation harness (Phase 0)
+
+Built once, reusable:
+
+- **Query tagging:** heavy statements get `log_comment` values
+  (`sp-insert`, `sp-leafbounds`, `rollup-z{N}`, `q-leafpoints`) so they are
+  identifiable in CH system tables. Gated by env `CLUSTOPHER_CH_PROFILE=1`;
+  the production path is unchanged when unset.
+- **Per-query profiling settings** (same gate):
+  - `log_processors_profiles = 1` — per-operator elapsed/rows in
+    `system.processors_profile_log`; splits the INSERT pipeline into
+    read → sort → spill-merge → rowNumber → MergeTree sink.
+  - `query_profiler_real_time_period_ns = 10ms`,
+    `query_profiler_cpu_time_period_ns = 10ms` — sampled stacks into
+    `system.trace_log`.
+- **Analysis queries** saved as `.sql` files (run post-bench):
+  - `system.query_log` — wall, `memory_usage`, `read_rows/bytes`,
+    ProfileEvents (`ExternalSortWritePart`, `ExternalSortMerge`, disk I/O)
+    per tagged query.
+  - `system.processors_profile_log` — per-operator `elapsed_us` / rows.
+    The key table: distinguishes sort vs spill vs single-threaded
+    `rowNumberInAllBlocks` merge vs MergeTree sink cost.
+  - `system.trace_log` — top stacks aggregated.
+- **Go side (query track):** pprof CPU + heap around the z14 bench loop;
+  CH side of `fetchLeafPoints` via the same tagging.
+- **Per-zoom rollup timing:** `populateRollupsBatch` currently logs all 9
+  zooms as one lump; add per-zoom timing.
+
+## Baseline capture @ 100M (Phase 1)
+
+One instrumented run: single-pass load + z2/z8/z14 query bench. Output: an
+evidence report ranking time sinks, saved to `benchmark_results/`.
+
+## Fix loop (Phase 2)
+
+Top finding → change → re-run 100M → keep or revert. One change at a time.
+
+Candidate hypotheses going in (evidence reorders or kills them):
+
+| # | Hypothesis | Track |
+|---|------------|-------|
+| H1 | Rollup cascade z10→z2 kills 8 of 9 full scans. `tile(z-1) = intDiv(tile(z), 2)` is exact because `floor(floor(v)/2) == floor(v/2)`; all rollup columns are additive. | Load |
+| H2 | INSERT dominated by external-sort spill merge passes + single-threaded `rowNumberInAllBlocks` final merge. | Load |
+| H3 | Pre-sorted staging (morton key materialized into ORDER BY) eliminates the runtime sort. Schema migration — only if profiling proves sort dominates AND settings cannot fix it. | Load |
+| H4 | Spill/thread settings suboptimal (1 GB external-sort threshold is very aggressive). | Load |
+| H5 | z14 time split between CH fetch volume (Map columns?) and Go-side clustering; 993 MB alloc/op says Go allocations matter. | Query |
+
+**Hard constraint:** every kept change must respect the 3B anti-OOM math
+(80 GB query cap, spill bounds, 94 GB host). No change that only works when
+100M fits in RAM.
+
+## Final verify (Phase 3)
+
+3B run with the kept set. Update README scale + latency tables. Existing
+tests (`go test ./cluster`, golden/validation) stay green throughout.
+
+## Non-goals
+
+- No staging-schema migration unless H3 is proven necessary (see above).
+- No distributed CH.
+- No query-semantics changes — results must stay byte-identical.

--- a/frontend/src/components/ClusterSelector.svelte
+++ b/frontend/src/components/ClusterSelector.svelte
@@ -227,7 +227,7 @@
                                 </button>
                             </div>
                             <div class="cluster-details">
-                                <span class="timestamp">{new Date(cluster.timestamp).toLocaleString()}</span>
+                                <span class="cluster-id" title="Cluster ID">{cluster.id}</span>
                                 <span class="size">{(cluster.fileSize / (1024 * 1024)).toFixed(1)} MB</span>
                             </div>
                         </div>

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -3,8 +3,10 @@ package runner
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"sync"
 	"time"
 
@@ -82,6 +84,12 @@ func (r *ClusterRunner) loadClusterIfNeeded(ctx context.Context, id string) (*cl
 
 	// Slow path: build skeleton from CH outside the lock so we don't hold it
 	// during a potentially long network call.
+	zsplit := 11
+	if v := os.Getenv("CLUSTOPHER_ZSPLIT"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil {
+			zsplit = parsed
+		}
+	}
 	sc := cluster.NewSupercluster(cluster.SuperclusterOptions{
 		MinZoom:   0,
 		MaxZoom:   16,
@@ -89,6 +97,7 @@ func (r *ClusterRunner) loadClusterIfNeeded(ctx context.Context, id string) (*cl
 		Radius:    40,
 		Extent:    512,
 		NodeSize:  64,
+		ZSplit:    zsplit,
 	})
 	sc.SetCHClient(r.ch)
 	sc.SetClusterID(id)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -296,6 +296,28 @@ func (r *ClusterRunner) GetMetadata(ctx context.Context, req *pb.GetMetadataRequ
 	}
 	summary := cluster.CalculateMetadataSummary(clusters)
 
+	// summary.TotalPoints from CalculateMetadataSummary only counts what's
+	// visible in the current viewport. The UI sidebar wants the cluster's
+	// true total, so override with a direct SELECT count() against the
+	// canonical points table.
+	var totalPoints uint64
+	if err := r.ch.Conn().QueryRow(ctx,
+		"SELECT count() FROM clustopher.points WHERE cluster_id = ?",
+		req.ClusterId).Scan(&totalPoints); err != nil {
+		return nil, fmt.Errorf("count cluster points: %w", err)
+	}
+
+	// Backfill metadata distribution from CH. The rollup-MV path used at low
+	// zoom doesn't carry per-point metadata, so cluster nodes returned by
+	// GetClustersCH have empty Metadata maps when zoom < ZSplit. Probe the
+	// canonical points table directly within the viewport so the UI sidebar
+	// always shows metadata totals regardless of zoom.
+	metadataDist, err := r.queryMetadataDistribution(ctx, req.ClusterId, bounds)
+	if err != nil {
+		// Non-fatal — fall back to whatever CalculateMetadataSummary produced.
+		fmt.Printf("metadata distribution probe failed: %v\n", err)
+	}
+
 	// Convert metricsSummary
 	metricsSummary := make(map[string]*pb.MetricStats)
 	for metric, stats := range summary.MetricsSummary {
@@ -334,11 +356,66 @@ func (r *ClusterRunner) GetMetadata(ctx context.Context, req *pb.GetMetadataRequ
 		}
 	}
 
+	// Overlay CH-side metadata distribution on top of any in-memory summary.
+	// The CH probe is authoritative because it scans every point in the
+	// viewport (no rollup MV truncation, no skeleton path attribution gaps).
+	for key, valueCounts := range metadataDist {
+		metadataSummary[key] = &pb.MetadataValue{
+			Distribution: &pb.Distribution{Values: valueCounts},
+		}
+	}
+
 	return &pb.GetMetadataResponse{
-		TotalPoints:     int32(summary.TotalPoints),
+		TotalPoints:     int32(totalPoints),
 		NumClusters:     int32(summary.NumClusters),
 		NumSinglePoints: int32(summary.NumSinglePoints),
 		MetricsSummary:  metricsSummary,
 		MetadataSummary: metadataSummary,
 	}, nil
+}
+
+// queryMetadataDistribution returns a per-key map of metadata-value counts
+// across all points inside the viewport for the given cluster. It unrolls the
+// Map(String, String) metadata column via arrayJoin so categorical fields
+// (e.g. {"type":"test"}) end up as {"type": {"test": N}} in the response.
+func (r *ClusterRunner) queryMetadataDistribution(ctx context.Context, clusterID string, bounds cluster.KDBounds) (map[string]map[string]float64, error) {
+	rows, err := r.ch.Conn().Query(ctx, `
+        SELECT kv.1 AS k, kv.2 AS v, count() AS cnt
+        FROM (
+            SELECT arrayJoin(
+                arrayMap((mk, mv) -> (mk, mv), mapKeys(metadata), mapValues(metadata))
+            ) AS kv
+            FROM clustopher.points
+            WHERE cluster_id = ?
+              AND x BETWEEN ? AND ?
+              AND y BETWEEN ? AND ?
+        )
+        GROUP BY k, v
+        ORDER BY k, cnt DESC
+    `, clusterID, bounds.MinX, bounds.MaxX, bounds.MinY, bounds.MaxY)
+	if err != nil {
+		return nil, fmt.Errorf("metadata dist query: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]map[string]float64)
+	var (
+		k, v string
+		cnt  uint64
+	)
+	for rows.Next() {
+		if err := rows.Scan(&k, &v, &cnt); err != nil {
+			return nil, fmt.Errorf("scan metadata dist row: %w", err)
+		}
+		inner, ok := out[k]
+		if !ok {
+			inner = make(map[string]float64)
+			out[k] = inner
+		}
+		inner[v] = float64(cnt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("metadata dist rows: %w", err)
+	}
+	return out, nil
 }

--- a/scripts/chprof/operators.sql
+++ b/scripts/chprof/operators.sql
@@ -1,0 +1,26 @@
+-- Per-operator breakdown for one tagged query (most recent run wins).
+-- Params: {tag:String}, {lookback_min:UInt32}
+-- elapsed = actual work; input_wait/output_wait = stalled on upstream/downstream.
+SELECT
+    name AS processor,
+    count() AS instances,
+    round(sum(elapsed_us) / 1e6, 1) AS work_s,
+    round(max(elapsed_us) / 1e6, 1) AS work_s_max,
+    round(sum(input_wait_elapsed_us) / 1e6, 1) AS in_wait_s,
+    round(sum(output_wait_elapsed_us) / 1e6, 1) AS out_wait_s,
+    sum(input_rows) AS in_rows,
+    sum(output_rows) AS out_rows,
+    formatReadableSize(sum(input_bytes)) AS in_bytes
+FROM system.processors_profile_log
+WHERE query_id = (
+    SELECT query_id FROM system.query_log
+    WHERE type = 'QueryFinish'
+      AND log_comment = {tag:String}
+      AND event_time > now() - INTERVAL {lookback_min:UInt32} MINUTE
+    ORDER BY event_time DESC
+    LIMIT 1
+)
+GROUP BY processor
+ORDER BY work_s DESC
+LIMIT 25
+FORMAT PrettyCompactMonoBlock

--- a/scripts/chprof/query_summary.sql
+++ b/scripts/chprof/query_summary.sql
@@ -1,0 +1,24 @@
+-- Per-tag summary of profiled queries (log_comment set by chQueryCtx).
+-- Params: {lookback_min:UInt32}
+SELECT
+    log_comment AS tag,
+    count() AS queries,
+    round(sum(query_duration_ms) / 1000, 1) AS total_s,
+    formatReadableSize(max(memory_usage)) AS peak_mem,
+    sum(read_rows) AS read_rows,
+    formatReadableSize(sum(read_bytes)) AS read_bytes,
+    sum(written_rows) AS written_rows,
+    formatReadableSize(sum(written_bytes)) AS written_bytes,
+    sum(ProfileEvents['ExternalSortWritePart']) AS ext_sort_parts,
+    sum(ProfileEvents['ExternalSortMerge']) AS ext_sort_merges,
+    formatReadableSize(sum(ProfileEvents['ExternalProcessingUncompressedBytesTotal'])) AS ext_spill_bytes,
+    formatReadableSize(sum(ProfileEvents['OSReadBytes'])) AS os_read,
+    formatReadableSize(sum(ProfileEvents['OSWriteBytes'])) AS os_write,
+    round(sum(ProfileEvents['OSCPUVirtualTimeMicroseconds']) / 1e6, 1) AS cpu_s
+FROM system.query_log
+WHERE type = 'QueryFinish'
+  AND log_comment != ''
+  AND event_time > now() - INTERVAL {lookback_min:UInt32} MINUTE
+GROUP BY tag
+ORDER BY total_s DESC
+FORMAT PrettyCompactMonoBlock

--- a/scripts/chprof/report.sh
+++ b/scripts/chprof/report.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Dump CH-side profiling report for tagged queries (CLUSTOPHER_CH_PROFILE=1 runs).
+#
+# Usage:
+#   report.sh [lookback_minutes]            # summary of all tags
+#   report.sh [lookback_minutes] <tag> ...  # + operator/stack breakdown per tag
+set -euo pipefail
+
+CH="${CLICKHOUSE_HTTP:-http://127.0.0.1:18123}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOOKBACK="${1:-240}"
+shift || true
+
+curl -fsS "$CH/" --data-binary "SYSTEM FLUSH LOGS" > /dev/null
+
+echo "=== query summary (last ${LOOKBACK}m) ==="
+curl -fsS "$CH/?param_lookback_min=$LOOKBACK" --data-binary @"$DIR/query_summary.sql"
+
+for tag in "$@"; do
+    echo
+    echo "=== operators: $tag ==="
+    curl -fsS "$CH/?param_lookback_min=$LOOKBACK&param_tag=$tag" \
+        --data-binary @"$DIR/operators.sql"
+    echo
+    echo "=== top stacks: $tag ==="
+    curl -fsS "$CH/?param_lookback_min=$LOOKBACK&param_tag=$tag&allow_introspection_functions=1" \
+        --data-binary @"$DIR/stacks.sql"
+done

--- a/scripts/chprof/stacks.sql
+++ b/scripts/chprof/stacks.sql
@@ -1,0 +1,21 @@
+-- Top sampled CPU frames for one tagged query (most recent run).
+-- Params: {tag:String}, {lookback_min:UInt32}
+-- Needs allow_introspection_functions=1 (set by report.sh).
+SELECT
+    count() AS samples,
+    demangle(addressToSymbol(trace[1])) AS top_frame,
+    demangle(addressToSymbol(trace[2])) AS caller
+FROM system.trace_log
+WHERE trace_type = 'CPU'
+  AND query_id = (
+    SELECT query_id FROM system.query_log
+    WHERE type = 'QueryFinish'
+      AND log_comment = {tag:String}
+      AND event_time > now() - INTERVAL {lookback_min:UInt32} MINUTE
+    ORDER BY event_time DESC
+    LIMIT 1
+)
+GROUP BY top_frame, caller
+ORDER BY samples DESC
+LIMIT 20
+FORMAT PrettyCompactMonoBlock


### PR DESCRIPTION
## Summary

Scale Clustopher from a 300 M-point ceiling to a verified 1 B-point cluster on a single 94 GB / 24-core box, then wire the UI to surface the new dataset honestly.

### Headline numbers (1 B random CONUS points)

| | KD path (max 300 M) | Streaming + capped MVs |
|---|---|---|
| Total wall-clock (cold load) | n/a (OOM at 500 M) | **49 min** |
| Skeleton build + canonical insert | n/a | 46 min |
| Rollup OPTIMIZE FINAL | n/a | **7.4 s** |
| Resident Go heap after load | n/a | **1.58 GB** |
| z2 query (CONUS viewport) | n/a | 4.3 ms |
| z8 query (state viewport) | n/a | 14.2 ms |
| z14 query (city viewport, 68 986 clusters) | n/a | 1.00 s |

## What's in this PR

### Core: `LoadFromCHStreaming`

- Pushes the spatial sort into ClickHouse via `ORDER BY mortonEncode(lng_u32, lat_u32)`.
- Streams sorted rows back, builds `SkeletonLeaf` chunks of `NodeSize` rows on the fly, never materializes the full `[]KDPoint`.
- Concurrent fan-out of (external_id, internal_id) inserts into `point_id_map_load` via dedicated CH connections.
- Go heap stays bounded by the skeleton tree itself — about 1.5 MB per 1 M points.

Tradeoff: Morton ordering is a Z-order approximation of the exact KD median partition. Leaf bounds are slightly looser so z14 returns ~15 % more points at viewport edges. `TestCHStreamingMatchesKD` (gated by `CLUSTOPHER_STREAMING_PARITY=1`) verifies low/mid-zoom rollup results match exactly while skeleton-path divergence stays under 25 %.

### Rollup MV cap (`MinRollupZoom` / `MaxRollupZoom`)

`ZSplit = 11` already routed every `zoom >= 11` query to the skeleton tree, so the `rollup_z11..z16` MVs were being maintained on every insert and never read. Capping MV creation at `z10`:

- Load wall-clock: ~46 % faster at 1 B (less per-insert write amplification across 15 MVs → 9 MVs).
- `OPTIMIZE FINAL`: drops from ~39 min to seconds at 1 B (z16's tile grid is 65536² — its MV held nearly 1 B rollup rows whose FINAL merge dominated everything).
- Read path is unchanged (no MV existed for those zooms in any prior PR).

### Rollup metric correctness

`rollup_z*` `metric_sums` / `metric_cnts` were plain `Map(String, Float64/UInt64)`. `SummingMergeTree` does NOT auto-merge plain Map columns, so per-tile sums silently collapsed to one row's metrics after merge. Changed to `SimpleAggregateFunction(sumMap, Map(...))` so SummingMT actually sums on merge.

`TestMetricRollupAllZooms` (`CLUSTOPHER_METRIC_ROLLUP=1`) now passes end-to-end: rollup z2-z10 direct probes AND `GetClustersCH` z2-z16 (rollup + skeleton paths) both return exact metric totals across 15 zoom levels.

### `populatePointsFromStaging` JOIN settings

- Forces `join_algorithm='full_sorting_merge'` so the staging × id_map join streams through sort-merge instead of building a 10-20 GB hash table at 500 M+.
- Dropped the trailing `ORDER BY m.internal_id`. MergeTree sorts blocks on insert via its table `ORDER BY` anyway; re-sorting 1 B rows in the JOIN output was costing ~70 GB of CH-server RAM at 500 M.

### UI / API fixes

- `GetMetadata.TotalPoints` was the viewport-clipped sum from `CalculateMetadataSummary`. Replaced with a direct `SELECT count() FROM clustopher.points WHERE cluster_id=?` so the sidebar shows the cluster's true total.
- Added `queryMetadataDistribution`: viewport-bounded SQL probe that unrolls the `Map(String, String)` metadata column via `arrayJoin` and groups by `(key, value)`. The rollup MV path returns ClusterNodes with empty Metadata maps, so without this the sidebar showed nothing at low zoom regardless of how rich the source data was.
- Frontend: dropped `new Date(cluster.timestamp).toLocaleString()` (backend never populated `timestamp`, so it always rendered "Invalid Date"). Show the cluster id instead — the only stable identifier the UI has.

### Test infrastructure

- `TestScalePerf` (`CLUSTOPHER_SCALE_TESTS=1`, `CLUSTOPHER_SCALE_STREAMING=1`) — multi-size sweep, emits a markdown report.
- `TestSeedNYC15M` (`SEED_NYC_15M=1`) — seeds a 15 M-point cluster confined to NYC bounds, for UI smoke testing.
- `generateDenseStagingPoints` now emits genuinely useful synthetic data:
  - metrics: `price` (\$0-500), `rating` (1-5), `visitors` (0-10k)
  - metadata: `category` (5 buckets), `borough` (5 buckets), `verified` (70/30), `tier` (gold/silver/bronze 10/30/60)
  - All draws use distinct `cityHash64(number, salt)` per axis/field so they're mutually independent.

## Test plan

- [ ] `CLICKHOUSE_DSN=... go test ./cluster -count=1` — full unit suite (~2 s).
- [ ] `CLUSTOPHER_METRIC_ROLLUP=1 CLICKHOUSE_DSN=... go test ./cluster -run TestMetricRollup -v` — metric correctness across rollup + skeleton paths.
- [ ] `CLUSTOPHER_STREAMING_PARITY=1 CLICKHOUSE_DSN=... go test ./cluster -run TestCHStreamingMatchesKD -v` — KD vs streaming parity at 1 M.
- [ ] `SEED_NYC_15M=1 CLUSTOPHER_CLUSTER_ID=NYC_15M CLICKHOUSE_DSN=... go test ./cluster -run TestSeedNYC15M -v` — seed a 15 M NYC cluster.
- [ ] Start `cmd/runners` + `cmd/api` + frontend, load NYC_15M cluster, verify sidebar shows 15 M points + 4 metadata distributions.
- [ ] Optional: `CLUSTOPHER_SCALE_TESTS=1 CLUSTOPHER_SCALE_STREAMING=1 CLUSTOPHER_SCALE_SIZES=100m,500m,1b CLICKHOUSE_DSN=... go test ./cluster -run TestScalePerf -v -timeout 4h` — reproduce the 1 B headline numbers (~3 hr).

## Out of scope (next steps)

- Wire `cmd/runners` `CreateCluster` to use `LoadFromCHStreaming` when `NumPoints > ~5M`. Currently it still calls `sc.Load(points)` (generates points in Go heap, won't scale past low millions from the UI).
- Lazy skeleton build: defer `Open()` until first `zoom >= ZSplit` query. Big cold-start win for clusters where users may never zoom past the rollup horizon.
- `LoadCluster` does eager `Open()` regardless of zoom; for 1 B-row clusters that's a non-trivial RSS spike before any query lands.
- Frontend `Children` / member-id usage is not yet driven by a UI feature; the new `attachAttrsFromMembers` aggregation costs ~260 MB/op at z14 / 1 B. Worth gating behind a `WithChildren bool` request flag once the UI stops needing them by default.